### PR TITLE
Add `pyrgiht` back

### DIFF
--- a/lua/lq/configs/lsp/lspconfig.lua
+++ b/lua/lq/configs/lsp/lspconfig.lua
@@ -95,7 +95,8 @@ end
 M.capabilities = cmp_nvim_lsp.default_capabilities(capabilities)
 
 local sumneko_opts = require("lq.configs.lsp.settings.sumneko_lua")
-local pyright_opts = require("lq.configs.lsp.settings.basedpyright")
+-- local basedpyrgiht = require("lq.configs.lsp.settings.basedpyright")
+local pyright = require("lq.configs.lsp.settings.pyright")
 
 lspconfig.lua_ls.setup({
 	on_attach = M.on_attach,
@@ -111,11 +112,18 @@ lspconfig.bashls.setup({
 	filetype = { "sh", "bash" },
 })
 
-lspconfig.basedpyright.setup({
+-- lspconfig.basedpyright.setup({
+-- 	on_attach = M.on_attach,
+-- 	capabilities = M.capabilities,
+--
+-- 	settings = basedpyrgiht.settings,
+-- })
+
+lspconfig.pyright.setup({
 	on_attach = M.on_attach,
 	capabilities = M.capabilities,
 
-	settings = pyright_opts.settings,
+	settings = pyright.settings,
 })
 
 lspconfig.clangd.setup({

--- a/lua/lq/configs/lsp/settings/pyright.lua
+++ b/lua/lq/configs/lsp/settings/pyright.lua
@@ -1,0 +1,18 @@
+return {
+  -- more settings see https://github.com/microsoft/pyright/blob/main/packages/vscode-pyright/package.json
+  settings = {
+    python = {
+      analysis = {
+        autoSearchPaths = true,
+        autoImportCompletions = false,
+        diagnosticMode = "workspace",
+        useLibraryCodeForTypes = true,
+        typeCheckingMode = "off",
+        logLevel = "Warning",
+        diagnosticSeverityOverrides = {
+          reportUnusedImport = "off",
+        },
+      },
+    },
+  }
+}


### PR DESCRIPTION
as there's inconsistent behaviors as I expected `basedpyrgiht` would be the same as `pyrgiht`
- some packages I can not directly jump into by lsp client
- the some variables highlighting are different, probably it's because with `basedpyrgiht` the some highlight groups are different

Might investigate this more later sometime, but now swtich back to pyrgiht