### PR TITLE
fix(lsp): unpin nvim-lspconfig to receive upstream updates

### DIFF
--- a/lua/lq/plugins/lsp.lua
+++ b/lua/lq/plugins/lsp.lua
@@ -3,7 +3,6 @@ return {
 		"neovim/nvim-lspconfig",
 		dependencies = { "mason.nvim", config = true },
 		event = "VeryLazy",
-    commit = "5bfcc89fd155b4ffc02d18ab3b7d19c2d4e246a7",
 		config = function()
 			require("lq.configs.lsp.lspconfig")
 			vim.cmd("silent! do FileType")


### PR DESCRIPTION
Removes the stale `commit` pin that locked `nvim-lspconfig` to an ~8 month old commit (2025-09-18).

This was causing the LSP client to miss upstream bug fixes, compatibility updates, and performance improvements for pyright and other language servers. Keeping the plugin tracking the default branch ensures timely updates through lazy.nvim.