### PR TITLE
fix(pyright): reduce RAM usage by switching to openFilesOnly diagnostics

### DIFF
--- a/lua/lq/configs/lsp/settings/pyright.lua
+++ b/lua/lq/configs/lsp/settings/pyright.lua
@@ -5,13 +5,14 @@ return {
       analysis = {
         autoSearchPaths = true,
         autoImportCompletions = false,
-        diagnosticMode = "workspace",
-        useLibraryCodeForTypes = true,
+        diagnosticMode = "openFilesOnly",
+        useLibraryCodeForTypes = false,
         typeCheckingMode = "off",
         logLevel = "Warning",
         diagnosticSeverityOverrides = {
           reportUnusedImport = "off",
         },
+        exclude = { "**/node_modules", "**/__pycache__", "**/.git", "**/.venv", "**/venv" },
       },
     },
   }


### PR DESCRIPTION
Tunes pyright settings to curb gradual memory growth.

**Changes:**
- `diagnosticMode`: `"workspace"` → `"openFilesOnly"`
- `useLibraryCodeForTypes`: `true` → `false`
- Adds `exclude` patterns for common non-source directories

**Why:**
`diagnosticMode = "workspace"` tells pyright to analyze the entire project (including dependencies) on every change. Combined with `useLibraryCodeForTypes = true`, this causes pyright to recursively scan and retain type info for libraries, leading to the observed gradual RAM increase and occasional heap-limit crashes. Since `typeCheckingMode` is already `"off"`, workspace-wide analysis provides little benefit while consuming significant memory.