### PR TITLE
Multi-agent manager for kimi-code sessions (sidebar + statusline)

### DIFF
--- a/lua/lq/configs/agents.lua
+++ b/lua/lq/configs/agents.lua
@@ -4,6 +4,8 @@
 -- interrupted / exited) comes from kimi-code hooks (see scripts/agent-status.sh),
 -- which write $KIMI_CODE_HOME/agent-status/<name>.json; a timer polls that
 -- directory and refreshes the sidebar and the heirline component.
+-- Exited agents stay in the registry (so their float can still be toggled)
+-- but are hidden from the sidebar, picker and statusline.
 
 local M = {}
 
@@ -23,13 +25,13 @@ local INDEX_FILE = KIMI_HOME .. "/session_index.jsonl"
 
 local STATE_ICON = {
 	running = "●",
-	idle = "○",
+	idle = "●",
 	interrupted = "◐",
 	exited = "✕",
 }
 local STATE_HL = {
-	running = "DiagnosticOk",
-	idle = "Comment",
+	running = "DiagnosticWarn",
+	idle = "DiagnosticOk",
 	interrupted = "DiagnosticWarn",
 	exited = "DiagnosticError",
 }
@@ -67,6 +69,18 @@ local function find_by_session(session_id)
 		end
 	end
 	return nil
+end
+
+---Agents that are still alive (exited ones are hidden from all UI).
+---@return KimiAgent[]
+local function visible_agents()
+	local out = {}
+	for _, a in ipairs(M.agents) do
+		if a.state ~= "exited" then
+			table.insert(out, a)
+		end
+	end
+	return out
 end
 
 local function next_count()
@@ -164,13 +178,14 @@ function M._render_sidebar()
 	if not sb.buf or not vim.api.nvim_buf_is_valid(sb.buf) then
 		return
 	end
-	local lines = { "Kimi Agents (" .. #M.agents .. ")", "" }
+	local agents = visible_agents()
+	local lines = { "Kimi Agents (" .. #agents .. ")", "" }
 	local hls = {}
 	sb.line_map = {}
-	if #M.agents == 0 then
+	if #agents == 0 then
 		table.insert(lines, "  no agents — n to spawn")
 	end
-	for _, a in ipairs(M.agents) do
+	for _, a in ipairs(agents) do
 		local header = string.format("%s %s [%s]", STATE_ICON[a.state] or "?", a.name, a.state)
 		sb.line_map[#lines + 1] = a.name
 		table.insert(lines, header)
@@ -202,6 +217,31 @@ local function sidebar_agent_at_cursor()
 		end
 	end
 	return nil
+end
+
+---Move the cursor to the previous/next agent header (wraps around).
+---@param direction integer -1 for up, 1 for down
+local function sidebar_jump(direction)
+	local sb = M._sidebar
+	local headers = {}
+	for l in pairs(sb.line_map) do
+		table.insert(headers, l)
+	end
+	if #headers == 0 then
+		return
+	end
+	table.sort(headers)
+	local cur = vim.api.nvim_win_get_cursor(0)[1]
+	local target = direction < 0 and headers[#headers] or headers[1]
+	for _, l in ipairs(headers) do
+		if direction < 0 and l < cur then
+			target = l
+		elseif direction > 0 and l > cur then
+			target = l
+			break
+		end
+	end
+	vim.api.nvim_win_set_cursor(0, { target, 0 })
 end
 
 local function sidebar_close()
@@ -244,8 +284,15 @@ function M.sidebar_toggle()
 			M.resume()
 		end, vim.tbl_extend("force", opts, { desc = "resume kimi session" }))
 		vim.keymap.set("n", "q", sidebar_close, vim.tbl_extend("force", opts, { desc = "close sidebar" }))
+		-- jump between agents with one up/down (this config maps i=up, k=down)
+		vim.keymap.set("n", "i", function()
+			sidebar_jump(-1)
+		end, vim.tbl_extend("force", opts, { desc = "previous agent" }))
+		vim.keymap.set("n", "k", function()
+			sidebar_jump(1)
+		end, vim.tbl_extend("force", opts, { desc = "next agent" }))
 	end
-	vim.cmd("topleft 34vsplit")
+	vim.cmd("botright 34vsplit")
 	sb.win = vim.api.nvim_get_current_win()
 	vim.api.nvim_win_set_buf(sb.win, sb.buf)
 	vim.wo[sb.win].winfixwidth = true
@@ -313,9 +360,10 @@ function M.toggle(name)
 end
 
 function M.toggle_last()
-	local agent = (M._last and find(M._last)) or M.agents[#M.agents]
+	local visible = visible_agents()
+	local agent = (M._last and find(M._last)) or visible[#visible]
 	if not agent then
-		notify("no agents yet — <leader>Kn to spawn one")
+		notify("no agents yet — <leader>kn to spawn one")
 		return
 	end
 	M.toggle(agent.name)
@@ -347,11 +395,12 @@ end
 ---@param prompt string|nil
 ---@param cb fun(name:string)|nil defaults to toggling
 function M.pick(prompt, cb)
-	if #M.agents == 0 then
-		notify("no agents yet — <leader>Kn to spawn one")
+	local agents = visible_agents()
+	if #agents == 0 then
+		notify("no agents yet — <leader>kn to spawn one")
 		return
 	end
-	vim.ui.select(M.agents, {
+	vim.ui.select(agents, {
 		prompt = prompt or "Kimi agents",
 		format_item = function(a)
 			local title = a.title ~= "" and (" — " .. a.title) or ""
@@ -433,35 +482,37 @@ end
 
 -- -------------------------------------------------------------- statusline --
 
+---Number of live (non-exited) agents; used by the heirline condition.
 function M.count()
-	return #M.agents
+	return #visible_agents()
 end
 
----@return integer running, integer total
+---@return integer running, integer total (live agents only)
 function M.status()
 	local running = 0
-	for _, a in ipairs(M.agents) do
+	local agents = visible_agents()
+	for _, a in ipairs(agents) do
 		if a.state == "running" then
 			running = running + 1
 		end
 	end
-	return running, #M.agents
+	return running, #agents
 end
 
 -- ------------------------------------------------------------------- setup --
 
 function M.setup()
 	local map = vim.keymap.set
-	map("n", "<leader>K", M.toggle_last, { desc = "kimi: toggle last agent" })
-	map("n", "<leader>Kn", function()
+	map("n", "<leader>k", M.toggle_last, { desc = "kimi: toggle last agent" })
+	map("n", "<leader>kn", function()
 		M.spawn()
 	end, { desc = "kimi: new agent" })
-	map("n", "<leader>Kr", M.resume, { desc = "kimi: resume session" })
-	map("n", "<leader>Ka", M.sidebar_toggle, { desc = "kimi: agents sidebar" })
-	map("n", "<leader>Kl", function()
+	map("n", "<leader>kr", M.resume, { desc = "kimi: resume session" })
+	map("n", "<leader>ka", M.sidebar_toggle, { desc = "kimi: agents sidebar" })
+	map("n", "<leader>kl", function()
 		M.pick()
 	end, { desc = "kimi: list agents" })
-	map("n", "<leader>Kx", function()
+	map("n", "<leader>kx", function()
 		M.kill()
 	end, { desc = "kimi: kill agent" })
 end

--- a/lua/lq/configs/agents.lua
+++ b/lua/lq/configs/agents.lua
@@ -127,6 +127,11 @@ local function refresh()
 end
 
 -- ---------------------------------------------------------------- polling --
+--
+-- Known limitation (accepted in review): killing an agent within ~2s of
+-- spawning — before its session_id is known — leaves no tombstone, so a late
+-- hook write from it can briefly leak state into an immediate same-named
+-- respawn. Self-heals on the next hook event; recover by killing/respawning.
 
 local function poll()
 	if #M.agents == 0 then

--- a/lua/lq/configs/agents.lua
+++ b/lua/lq/configs/agents.lua
@@ -416,13 +416,9 @@ function M.toggle_last()
 	M.toggle(agent.name)
 end
 
+---@param name string agent name (sidebar always passes one)
+---@param force boolean|nil skip the confirm dialog
 function M.kill(name, force)
-	if not name then
-		M.pick("Kill agent", function(choice)
-			M.kill(choice)
-		end)
-		return
-	end
 	local agent, idx = find(name)
 	if not agent then
 		return
@@ -437,29 +433,6 @@ function M.kill(name, force)
 	end
 	vim.fn.delete(STATUS_DIR .. "/" .. name .. ".json")
 	refresh()
-end
-
----@param prompt string|nil
----@param cb fun(name:string)|nil defaults to toggling
-function M.pick(prompt, cb)
-	local agents = visible_agents()
-	if #agents == 0 then
-		notify("no agents yet — <leader>kn to spawn one")
-		return
-	end
-	vim.ui.select(agents, {
-		prompt = prompt or "Kimi agents",
-		format_item = function(a)
-			local title = a.title ~= "" and (" — " .. a.title) or ""
-			return string.format("%s %s [%s]%s", STATE_ICON[a.state] or "?", a.name, a.state, title)
-		end,
-	}, function(choice)
-		if choice then
-			(cb or function(name)
-				M.toggle(name)
-			end)(choice.name)
-		end
-	end)
 end
 
 ---Resume an existing kimi-code session of this project in a new agent float.

--- a/lua/lq/configs/agents.lua
+++ b/lua/lq/configs/agents.lua
@@ -24,6 +24,9 @@ local KIMI_HOME = vim.env.KIMI_CODE_HOME or (vim.fn.expand("~/.kimi-code"))
 local STATUS_DIR = KIMI_HOME .. "/agent-status"
 local INDEX_FILE = KIMI_HOME .. "/session_index.jsonl"
 
+local NS_STATE = vim.api.nvim_create_namespace("kimi_agents_state")
+local NS_CURSOR = vim.api.nvim_create_namespace("kimi_agents_cursor")
+
 local STATE_ICON = {
 	running = "●",
 	idle = "●",
@@ -40,7 +43,7 @@ local STATE_HL = {
 M._last = nil ---@type string|nil
 M._next_count = 101
 M._timer = nil
-M._sidebar = { buf = nil, win = nil, line_map = {} }
+M._sidebar = { buf = nil, win = nil, line_map = {}, block_map = {} }
 
 local function notify(msg, level)
 	vim.notify(msg, level or vim.log.levels.INFO, { title = "kimi agents" })
@@ -158,6 +161,7 @@ end
 
 -- ---------------------------------------------------------------- sidebar --
 
+local SIDEBAR_WIDTH = 42
 local PREVIEW_LINES = 2
 
 local function preview_lines(agent)
@@ -179,6 +183,27 @@ local function preview_lines(agent)
 	return out
 end
 
+---Highlight the whole block of the agent under the cursor.
+local function sidebar_highlight_current()
+	local sb = M._sidebar
+	if not sb.buf or not vim.api.nvim_buf_is_valid(sb.buf) then
+		return
+	end
+	vim.api.nvim_buf_clear_namespace(sb.buf, NS_CURSOR, 0, -1)
+	if not sb.win or not vim.api.nvim_win_is_valid(sb.win) then
+		return
+	end
+	local cur = vim.api.nvim_win_get_cursor(sb.win)[1]
+	for _, b in ipairs(sb.block_map) do
+		if cur >= b.first and cur <= b.last then
+			for l = b.first - 1, b.last - 1 do
+				vim.api.nvim_buf_add_highlight(sb.buf, NS_CURSOR, "KimiAgentsCurrent", l, 0, -1)
+			end
+			return
+		end
+	end
+end
+
 function M._render_sidebar()
 	local sb = M._sidebar
 	if not sb.buf or not vim.api.nvim_buf_is_valid(sb.buf) then
@@ -188,12 +213,14 @@ function M._render_sidebar()
 	local lines = { "Kimi Agents (" .. #agents .. ")", "" }
 	local hls = {}
 	sb.line_map = {}
+	sb.block_map = {}
 	if #agents == 0 then
 		table.insert(lines, "  no agents — n to spawn")
 	end
 	for _, a in ipairs(agents) do
 		local header = string.format("%s %s [%s]", STATE_ICON[a.state] or "?", a.name, a.state)
-		sb.line_map[#lines + 1] = a.name
+		local first = #lines + 1
+		sb.line_map[first] = a.name
 		table.insert(lines, header)
 		table.insert(hls, { line = #lines - 1, hl = STATE_HL[a.state] or "Comment" })
 		if a.title ~= "" then
@@ -202,15 +229,17 @@ function M._render_sidebar()
 		for _, p in ipairs(preview_lines(a)) do
 			table.insert(lines, "  │ " .. p:sub(1, 60))
 		end
+		table.insert(sb.block_map, { first = first, last = #lines })
 		table.insert(lines, "")
 	end
 	vim.bo[sb.buf].modifiable = true
 	vim.api.nvim_buf_set_lines(sb.buf, 0, -1, false, lines)
-	vim.api.nvim_buf_clear_namespace(sb.buf, -1, 0, -1)
+	vim.api.nvim_buf_clear_namespace(sb.buf, NS_STATE, 0, -1)
 	for _, h in ipairs(hls) do
-		vim.api.nvim_buf_add_highlight(sb.buf, -1, h.hl, h.line, 0, 1)
+		vim.api.nvim_buf_add_highlight(sb.buf, NS_STATE, h.hl, h.line, 0, 1)
 	end
 	vim.bo[sb.buf].modifiable = false
+	sidebar_highlight_current()
 end
 
 local function sidebar_agent_at_cursor()
@@ -248,6 +277,7 @@ local function sidebar_jump(direction)
 		end
 	end
 	vim.api.nvim_win_set_cursor(0, { target, 0 })
+	sidebar_highlight_current()
 end
 
 local function sidebar_close()
@@ -264,6 +294,7 @@ function M.sidebar_toggle()
 		sidebar_close()
 		return
 	end
+	vim.api.nvim_set_hl(0, "KimiAgentsCurrent", { link = "CursorLine" })
 	if not sb.buf or not vim.api.nvim_buf_is_valid(sb.buf) then
 		sb.buf = vim.api.nvim_create_buf(false, true)
 		vim.bo[sb.buf].buftype = "nofile"
@@ -277,12 +308,14 @@ function M.sidebar_toggle()
 				M.toggle(name)
 			end
 		end, vim.tbl_extend("force", opts, { desc = "toggle agent float" }))
-		vim.keymap.set("n", "d", function()
+		local kill_at_cursor = function()
 			local name = sidebar_agent_at_cursor()
 			if name then
 				M.kill(name)
 			end
-		end, vim.tbl_extend("force", opts, { desc = "kill agent" }))
+		end
+		vim.keymap.set("n", "d", kill_at_cursor, vim.tbl_extend("force", opts, { desc = "kill agent" }))
+		vim.keymap.set("n", "x", kill_at_cursor, vim.tbl_extend("force", opts, { desc = "kill agent" }))
 		vim.keymap.set("n", "n", function()
 			M.spawn()
 		end, vim.tbl_extend("force", opts, { desc = "new agent" }))
@@ -297,8 +330,12 @@ function M.sidebar_toggle()
 		vim.keymap.set("n", "k", function()
 			sidebar_jump(1)
 		end, vim.tbl_extend("force", opts, { desc = "next agent" }))
+		vim.api.nvim_create_autocmd("CursorMoved", {
+			buffer = sb.buf,
+			callback = sidebar_highlight_current,
+		})
 	end
-	vim.cmd("botright 34vsplit")
+	vim.cmd("botright " .. SIDEBAR_WIDTH .. "vsplit")
 	sb.win = vim.api.nvim_get_current_win()
 	vim.api.nvim_win_set_buf(sb.win, sb.buf)
 	vim.wo[sb.win].winfixwidth = true
@@ -524,12 +561,6 @@ function M.setup()
 	end, { desc = "kimi: new agent" })
 	map("n", "<leader>kr", M.resume, { desc = "kimi: resume session" })
 	map("n", "<leader>ka", M.sidebar_toggle, { desc = "kimi: agents sidebar" })
-	map("n", "<leader>kl", function()
-		M.pick()
-	end, { desc = "kimi: list agents" })
-	map("n", "<leader>kx", function()
-		M.kill()
-	end, { desc = "kimi: kill agent" })
 end
 
 return M

--- a/lua/lq/configs/agents.lua
+++ b/lua/lq/configs/agents.lua
@@ -1,0 +1,465 @@
+-- Multi-agent manager for kimi-code CLI sessions running in toggleterm floats.
+--
+-- Each agent is a named toggleterm Terminal (float). Status (running / idle /
+-- interrupted / exited) comes from kimi-code hooks (see scripts/agent-status.sh),
+-- which write $KIMI_CODE_HOME/agent-status/<name>.json; a timer polls that
+-- directory and refreshes the sidebar and the heirline component.
+
+local M = {}
+
+---@class KimiAgent
+---@field name string
+---@field term table toggleterm Terminal
+---@field state "running"|"idle"|"interrupted"|"exited"
+---@field title string
+---@field session_id string|nil
+
+---@type KimiAgent[]
+M.agents = {}
+
+local KIMI_HOME = vim.env.KIMI_CODE_HOME or (vim.fn.expand("~/.kimi-code"))
+local STATUS_DIR = KIMI_HOME .. "/agent-status"
+local INDEX_FILE = KIMI_HOME .. "/session_index.jsonl"
+
+local STATE_ICON = {
+	running = "●",
+	idle = "○",
+	interrupted = "◐",
+	exited = "✕",
+}
+local STATE_HL = {
+	running = "DiagnosticOk",
+	idle = "Comment",
+	interrupted = "DiagnosticWarn",
+	exited = "DiagnosticError",
+}
+
+M._last = nil ---@type string|nil
+M._next_count = 101
+M._timer = nil
+M._sidebar = { buf = nil, win = nil, line_map = {} }
+
+local function notify(msg, level)
+	vim.notify(msg, level or vim.log.levels.INFO, { title = "kimi agents" })
+end
+
+local function sanitize(name)
+	return (name:gsub("[/\\]", "-"):gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+local function project_root()
+	return vim.fs.root(0, ".git") or vim.fn.getcwd()
+end
+
+local function find(name)
+	for i, a in ipairs(M.agents) do
+		if a.name == name then
+			return a, i
+		end
+	end
+	return nil, nil
+end
+
+local function find_by_session(session_id)
+	for _, a in ipairs(M.agents) do
+		if a.session_id == session_id then
+			return a
+		end
+	end
+	return nil
+end
+
+local function next_count()
+	local n = M._next_count
+	M._next_count = M._next_count + 1
+	return n
+end
+
+local function refresh()
+	vim.cmd("redrawstatus")
+	M._render_sidebar()
+end
+
+-- ---------------------------------------------------------------- polling --
+
+local function poll()
+	if #M.agents == 0 then
+		return
+	end
+	local changed = false
+	for _, entry in ipairs(vim.fn.glob(STATUS_DIR .. "/*.json", false, true)) do
+		local ok, lines = pcall(vim.fn.readfile, entry)
+		if ok and lines[1] then
+			local ok2, status = pcall(vim.json.decode, table.concat(lines, "\n"))
+			if ok2 and type(status) == "table" then
+				local agent = (status.name and find(status.name))
+					or (status.session_id and find_by_session(status.session_id))
+				if agent then
+					if status.state and agent.state ~= status.state then
+						agent.state = status.state
+						changed = true
+					end
+					if status.session_id and status.session_id ~= "" and not agent.session_id then
+						agent.session_id = status.session_id
+						changed = true
+					end
+					if status.title and status.title ~= "" and agent.title ~= status.title then
+						agent.title = status.title
+						changed = true
+					end
+				end
+			end
+		end
+	end
+	if changed then
+		refresh()
+	end
+end
+
+local function start_timer()
+	if M._timer then
+		return
+	end
+	M._timer = vim.uv.new_timer()
+	M._timer:start(
+		1000,
+		2000,
+		vim.schedule_wrap(function()
+			if #M.agents == 0 then
+				M._timer:stop()
+				M._timer:close()
+				M._timer = nil
+				return
+			end
+			pcall(poll)
+		end)
+	)
+end
+
+-- ---------------------------------------------------------------- sidebar --
+
+local PREVIEW_LINES = 2
+
+local function preview_lines(agent)
+	local term = agent.term
+	if not term.bufnr or not vim.api.nvim_buf_is_valid(term.bufnr) then
+		return {}
+	end
+	local lines = vim.api.nvim_buf_get_lines(term.bufnr, -60, -1, false)
+	local out = {}
+	for i = #lines, 1, -1 do
+		local s = vim.trim(lines[i])
+		if s ~= "" then
+			table.insert(out, 1, s)
+		end
+		if #out >= PREVIEW_LINES then
+			break
+		end
+	end
+	return out
+end
+
+function M._render_sidebar()
+	local sb = M._sidebar
+	if not sb.buf or not vim.api.nvim_buf_is_valid(sb.buf) then
+		return
+	end
+	local lines = { "Kimi Agents (" .. #M.agents .. ")", "" }
+	local hls = {}
+	sb.line_map = {}
+	if #M.agents == 0 then
+		table.insert(lines, "  no agents — n to spawn")
+	end
+	for _, a in ipairs(M.agents) do
+		local header = string.format("%s %s [%s]", STATE_ICON[a.state] or "?", a.name, a.state)
+		sb.line_map[#lines + 1] = a.name
+		table.insert(lines, header)
+		table.insert(hls, { line = #lines - 1, hl = STATE_HL[a.state] or "Comment" })
+		if a.title ~= "" then
+			table.insert(lines, "  " .. a.title)
+		end
+		for _, p in ipairs(preview_lines(a)) do
+			table.insert(lines, "  │ " .. p:sub(1, 60))
+		end
+		table.insert(lines, "")
+	end
+	vim.bo[sb.buf].modifiable = true
+	vim.api.nvim_buf_set_lines(sb.buf, 0, -1, false, lines)
+	vim.api.nvim_buf_clear_namespace(sb.buf, -1, 0, -1)
+	for _, h in ipairs(hls) do
+		vim.api.nvim_buf_add_highlight(sb.buf, -1, h.hl, h.line, 0, 1)
+	end
+	vim.bo[sb.buf].modifiable = false
+end
+
+local function sidebar_agent_at_cursor()
+	local sb = M._sidebar
+	local line = vim.api.nvim_win_get_cursor(0)[1]
+	-- nearest mapped header line at or above the cursor
+	for l = line, 1, -1 do
+		if sb.line_map[l] then
+			return sb.line_map[l]
+		end
+	end
+	return nil
+end
+
+local function sidebar_close()
+	local sb = M._sidebar
+	if sb.win and vim.api.nvim_win_is_valid(sb.win) then
+		vim.api.nvim_win_close(sb.win, true)
+	end
+	sb.win = nil
+end
+
+function M.sidebar_toggle()
+	local sb = M._sidebar
+	if sb.win and vim.api.nvim_win_is_valid(sb.win) then
+		sidebar_close()
+		return
+	end
+	if not sb.buf or not vim.api.nvim_buf_is_valid(sb.buf) then
+		sb.buf = vim.api.nvim_create_buf(false, true)
+		vim.bo[sb.buf].buftype = "nofile"
+		vim.bo[sb.buf].bufhidden = "hide"
+		vim.bo[sb.buf].swapfile = false
+		vim.bo[sb.buf].filetype = "kimiagents"
+		local opts = { buffer = sb.buf, silent = true, nowait = true }
+		vim.keymap.set("n", "<CR>", function()
+			local name = sidebar_agent_at_cursor()
+			if name then
+				M.toggle(name)
+			end
+		end, vim.tbl_extend("force", opts, { desc = "toggle agent float" }))
+		vim.keymap.set("n", "d", function()
+			local name = sidebar_agent_at_cursor()
+			if name then
+				M.kill(name)
+			end
+		end, vim.tbl_extend("force", opts, { desc = "kill agent" }))
+		vim.keymap.set("n", "n", function()
+			M.spawn()
+		end, vim.tbl_extend("force", opts, { desc = "new agent" }))
+		vim.keymap.set("n", "r", function()
+			M.resume()
+		end, vim.tbl_extend("force", opts, { desc = "resume kimi session" }))
+		vim.keymap.set("n", "q", sidebar_close, vim.tbl_extend("force", opts, { desc = "close sidebar" }))
+	end
+	vim.cmd("topleft 34vsplit")
+	sb.win = vim.api.nvim_get_current_win()
+	vim.api.nvim_win_set_buf(sb.win, sb.buf)
+	vim.wo[sb.win].winfixwidth = true
+	vim.wo[sb.win].number = false
+	vim.wo[sb.win].relativenumber = false
+	vim.wo[sb.win].signcolumn = "no"
+	vim.wo[sb.win].wrap = false
+	M._render_sidebar()
+end
+
+-- -------------------------------------------------------------- lifecycle --
+
+---@param name string|nil prompt when nil
+---@param cmd string|nil defaults to "kimi"
+function M.spawn(name, cmd)
+	if not name then
+		vim.ui.input({ prompt = "Agent name: " }, function(input)
+			if input and vim.trim(input) ~= "" then
+				M.spawn(input, cmd)
+			end
+		end)
+		return
+	end
+	name = sanitize(name)
+	local existing = find(name)
+	if existing then
+		M.toggle(name)
+		return existing
+	end
+	local Terminal = require("toggleterm.terminal").Terminal
+	local agent = { name = name, state = "idle", title = "", session_id = nil }
+	agent.term = Terminal:new({
+		cmd = cmd or "kimi",
+		direction = "float",
+		count = next_count(),
+		display_name = name,
+		dir = project_root(),
+		env = { KIMI_AGENT_NAME = name },
+		on_exit = function()
+			agent.state = "exited"
+			refresh()
+		end,
+	})
+	table.insert(M.agents, agent)
+	M._last = name
+	start_timer()
+	agent.term:toggle()
+	refresh()
+	return agent
+end
+
+function M.toggle(name)
+	local agent = find(name)
+	if not agent then
+		notify("no agent named " .. name, vim.log.levels.WARN)
+		return
+	end
+	agent.term:toggle()
+	M._last = name
+	refresh()
+end
+
+function M.toggle_last()
+	local agent = (M._last and find(M._last)) or M.agents[#M.agents]
+	if not agent then
+		notify("no agents yet — <leader>Kn to spawn one")
+		return
+	end
+	M.toggle(agent.name)
+end
+
+function M.kill(name, force)
+	if not name then
+		M.pick("Kill agent", function(choice)
+			M.kill(choice)
+		end)
+		return
+	end
+	local agent, idx = find(name)
+	if not agent then
+		return
+	end
+	if not force and vim.fn.confirm("Kill agent '" .. name .. "'?", "&Yes\n&No", 2) ~= 1 then
+		return
+	end
+	agent.term:shutdown()
+	table.remove(M.agents, idx)
+	if M._last == name then
+		M._last = nil
+	end
+	vim.fn.delete(STATUS_DIR .. "/" .. name .. ".json")
+	refresh()
+end
+
+---@param prompt string|nil
+---@param cb fun(name:string)|nil defaults to toggling
+function M.pick(prompt, cb)
+	if #M.agents == 0 then
+		notify("no agents yet — <leader>Kn to spawn one")
+		return
+	end
+	vim.ui.select(M.agents, {
+		prompt = prompt or "Kimi agents",
+		format_item = function(a)
+			local title = a.title ~= "" and (" — " .. a.title) or ""
+			return string.format("%s %s [%s]%s", STATE_ICON[a.state] or "?", a.name, a.state, title)
+		end,
+	}, function(choice)
+		if choice then
+			(cb or function(name)
+				M.toggle(name)
+			end)(choice.name)
+		end
+	end)
+end
+
+---Resume an existing kimi-code session of this project in a new agent float.
+function M.resume()
+	local root = project_root()
+	local f = io.open(INDEX_FILE, "r")
+	if not f then
+		notify("no kimi session index found", vim.log.levels.WARN)
+		return
+	end
+	local items = {}
+	for line in f:lines() do
+		local ok, rec = pcall(vim.json.decode, line)
+		if ok and type(rec) == "table" and rec.sessionId and rec.workDir == root then
+			local title = ""
+			if rec.sessionDir then
+				local sf = io.open(rec.sessionDir .. "/state.json", "r")
+				if sf then
+					local ok2, state = pcall(vim.json.decode, sf:read("*a"))
+					sf:close()
+					if ok2 and type(state) == "table" then
+						title = state.title or state.lastPrompt or ""
+					end
+				end
+			end
+			local mtime = 0
+			local stat = rec.sessionDir and vim.uv.fs_stat(rec.sessionDir .. "/state.json")
+			if stat then
+				mtime = stat.mtime.sec
+			end
+			table.insert(items, { id = rec.sessionId, title = title, mtime = mtime })
+		end
+	end
+	f:close()
+	if #items == 0 then
+		notify("no kimi sessions for " .. root)
+		return
+	end
+	table.sort(items, function(a, b)
+		return a.mtime > b.mtime
+	end)
+	vim.ui.select(items, {
+		prompt = "Resume kimi session",
+		format_item = function(it)
+			local label = it.title ~= "" and it.title or it.id:sub(9, 24)
+			label = label:gsub("\n", " "):sub(1, 50)
+			local when = it.mtime > 0 and os.date("%m-%d %H:%M", it.mtime) or "?"
+			return string.format("%s  (%s)", label, when)
+		end,
+	}, function(choice)
+		if not choice then
+			return
+		end
+		local open = find_by_session(choice.id)
+		if open then
+			M.toggle(open.name)
+			return
+		end
+		local name = (choice.title ~= "" and choice.title or choice.id:sub(9, 24)):gsub("\n", " "):sub(1, 30)
+		local agent = M.spawn(name, "kimi --session " .. choice.id)
+		if agent then
+			agent.session_id = choice.id
+			agent.title = choice.title:gsub("\n", " "):sub(1, 80)
+		end
+	end)
+end
+
+-- -------------------------------------------------------------- statusline --
+
+function M.count()
+	return #M.agents
+end
+
+---@return integer running, integer total
+function M.status()
+	local running = 0
+	for _, a in ipairs(M.agents) do
+		if a.state == "running" then
+			running = running + 1
+		end
+	end
+	return running, #M.agents
+end
+
+-- ------------------------------------------------------------------- setup --
+
+function M.setup()
+	local map = vim.keymap.set
+	map("n", "<leader>K", M.toggle_last, { desc = "kimi: toggle last agent" })
+	map("n", "<leader>Kn", function()
+		M.spawn()
+	end, { desc = "kimi: new agent" })
+	map("n", "<leader>Kr", M.resume, { desc = "kimi: resume session" })
+	map("n", "<leader>Ka", M.sidebar_toggle, { desc = "kimi: agents sidebar" })
+	map("n", "<leader>Kl", function()
+		M.pick()
+	end, { desc = "kimi: list agents" })
+	map("n", "<leader>Kx", function()
+		M.kill()
+	end, { desc = "kimi: kill agent" })
+end
+
+return M

--- a/lua/lq/configs/agents.lua
+++ b/lua/lq/configs/agents.lua
@@ -15,6 +15,7 @@ local M = {}
 ---@field state "running"|"idle"|"interrupted"|"exited"
 ---@field title string
 ---@field session_id string|nil
+---@field spawned_at integer|nil os.time() at spawn, used to ignore stale status files
 
 ---@type KimiAgent[]
 M.agents = {}
@@ -108,6 +109,11 @@ local function poll()
 			if ok2 and type(status) == "table" then
 				local agent = (status.name and find(status.name))
 					or (status.session_id and find_by_session(status.session_id))
+				-- ignore status written before this agent was spawned (stale
+				-- file from a previous life under the same name/session)
+				if agent and status.ts and agent.spawned_at and status.ts < agent.spawned_at then
+					agent = nil
+				end
 				if agent then
 					if status.state and agent.state ~= status.state then
 						agent.state = status.state
@@ -327,7 +333,11 @@ function M.spawn(name, cmd)
 		return existing
 	end
 	local Terminal = require("toggleterm.terminal").Terminal
-	local agent = { name = name, state = "idle", title = "", session_id = nil }
+	local agent = { name = name, state = "idle", title = "", session_id = nil, spawned_at = os.time() }
+	-- drop any stale status file from a previous life under the same name,
+	-- otherwise the poll would immediately mark the fresh agent with the
+	-- old state (e.g. "exited")
+	vim.fn.delete(STATUS_DIR .. "/" .. name .. ".json")
 	agent.term = Terminal:new({
 		cmd = cmd or "kimi",
 		direction = "float",
@@ -476,6 +486,11 @@ function M.resume()
 		if agent then
 			agent.session_id = choice.id
 			agent.title = choice.title:gsub("\n", " "):sub(1, 80)
+			-- the previous life of this session left an "exited" status file
+			-- behind (keyed by session id); drop it so the poll doesn't hide
+			-- the resumed agent
+			vim.fn.delete(STATUS_DIR .. "/" .. choice.id .. ".json")
+			refresh()
 		end
 	end)
 end

--- a/lua/lq/configs/agents.lua
+++ b/lua/lq/configs/agents.lua
@@ -6,6 +6,11 @@
 -- directory and refreshes the sidebar and the heirline component.
 -- Exited agents stay in the registry (so their float can still be toggled)
 -- but are hidden from the sidebar, picker and statusline.
+--
+-- UI notes: all colors come from semantic highlight links (Diagnostic* for
+-- states, Title/Comment/CursorLine for chrome) so the sidebar follows the
+-- active colorscheme; groups are namespaced KimiAgents* and re-applied on
+-- ColorScheme.
 
 local M = {}
 
@@ -39,6 +44,27 @@ local STATE_HL = {
 	interrupted = "DiagnosticWarn",
 	exited = "DiagnosticError",
 }
+
+---Namespaced, colorscheme-following highlight groups (default = user can override).
+local function set_hls()
+	local hls = {
+		KimiAgentsCurrent = { link = "CursorLine" }, -- agent block under the cursor
+		KimiAgentsHeader = { link = "Title" }, -- sidebar header line
+		KimiAgentsName = { bold = true }, -- agent name in its header line
+		KimiAgentsMuted = { link = "Comment" }, -- state tag, session title, preview
+	}
+	for group, def in pairs(hls) do
+		def.default = true
+		vim.api.nvim_set_hl(0, group, def)
+	end
+	-- hide the ~ column below the last sidebar line (fg = theme Normal bg)
+	local normal = vim.api.nvim_get_hl(0, { name = "Normal" })
+	if normal.bg then
+		vim.api.nvim_set_hl(0, "KimiAgentsEndOfBuffer", { fg = normal.bg, default = true })
+	end
+end
+set_hls()
+vim.api.nvim_create_autocmd("ColorScheme", { callback = set_hls })
 
 M._last = nil ---@type string|nil
 M._next_count = 101
@@ -211,23 +237,31 @@ function M._render_sidebar()
 	end
 	local agents = visible_agents()
 	local lines = { "Kimi Agents (" .. #agents .. ")", "" }
-	local hls = {}
+	-- highlight segments: { line (0-based), hl_group, col_start, col_end }
+	local segs = { { 0, "KimiAgentsHeader", 0, -1 } }
 	sb.line_map = {}
 	sb.block_map = {}
 	if #agents == 0 then
+		table.insert(segs, { #lines, "KimiAgentsMuted", 0, -1 })
 		table.insert(lines, "  no agents — n to spawn")
 	end
 	for _, a in ipairs(agents) do
-		local header = string.format("%s %s [%s]", STATE_ICON[a.state] or "?", a.name, a.state)
+		local icon = STATE_ICON[a.state] or "?"
+		local header = string.format("%s %s [%s]", icon, a.name, a.state)
 		local first = #lines + 1
 		sb.line_map[first] = a.name
 		table.insert(lines, header)
-		table.insert(hls, { line = #lines - 1, hl = STATE_HL[a.state] or "Comment" })
+		local line0 = #lines - 1
+		table.insert(segs, { line0, STATE_HL[a.state] or "Comment", 0, #icon })
+		table.insert(segs, { line0, "KimiAgentsName", #icon + 1, #icon + 1 + #a.name })
+		table.insert(segs, { line0, "KimiAgentsMuted", #icon + 1 + #a.name, -1 })
 		if a.title ~= "" then
+			table.insert(segs, { #lines, "KimiAgentsMuted", 0, -1 })
 			table.insert(lines, "  " .. a.title)
 		end
 		for _, p in ipairs(preview_lines(a)) do
-			table.insert(lines, "  │ " .. p:sub(1, 60))
+			table.insert(segs, { #lines, "KimiAgentsMuted", 0, -1 })
+			table.insert(lines, "  " .. vim.fn.strcharpart(p, 0, SIDEBAR_WIDTH - 4))
 		end
 		table.insert(sb.block_map, { first = first, last = #lines })
 		table.insert(lines, "")
@@ -235,8 +269,8 @@ function M._render_sidebar()
 	vim.bo[sb.buf].modifiable = true
 	vim.api.nvim_buf_set_lines(sb.buf, 0, -1, false, lines)
 	vim.api.nvim_buf_clear_namespace(sb.buf, NS_STATE, 0, -1)
-	for _, h in ipairs(hls) do
-		vim.api.nvim_buf_add_highlight(sb.buf, NS_STATE, h.hl, h.line, 0, 1)
+	for _, s in ipairs(segs) do
+		vim.api.nvim_buf_add_highlight(sb.buf, NS_STATE, s[2], s[1], s[3], s[4])
 	end
 	vim.bo[sb.buf].modifiable = false
 	sidebar_highlight_current()
@@ -294,7 +328,6 @@ function M.sidebar_toggle()
 		sidebar_close()
 		return
 	end
-	vim.api.nvim_set_hl(0, "KimiAgentsCurrent", { link = "CursorLine" })
 	if not sb.buf or not vim.api.nvim_buf_is_valid(sb.buf) then
 		sb.buf = vim.api.nvim_create_buf(false, true)
 		vim.bo[sb.buf].buftype = "nofile"
@@ -343,6 +376,9 @@ function M.sidebar_toggle()
 	vim.wo[sb.win].relativenumber = false
 	vim.wo[sb.win].signcolumn = "no"
 	vim.wo[sb.win].wrap = false
+	vim.wo[sb.win].list = false
+	vim.wo[sb.win].spell = false
+	vim.wo[sb.win].winhl = "EndOfBuffer:KimiAgentsEndOfBuffer"
 	M._render_sidebar()
 end
 

--- a/lua/lq/configs/agents.lua
+++ b/lua/lq/configs/agents.lua
@@ -21,6 +21,7 @@ local M = {}
 ---@field title string
 ---@field session_id string|nil
 ---@field spawned_at integer|nil os.time() at spawn, used to ignore stale status files
+---@field root string|nil project root at spawn, used to ignore status from other projects
 
 ---@type KimiAgent[]
 M.agents = {}
@@ -143,6 +144,20 @@ local function poll()
 				if agent and status.ts and agent.spawned_at and status.ts < agent.spawned_at then
 					agent = nil
 				end
+				-- ignore status from a different session or a different project
+				-- (the status dir is shared across all nvim instances)
+				if
+					agent
+					and agent.session_id
+					and status.session_id
+					and status.session_id ~= ""
+					and status.session_id ~= agent.session_id
+				then
+					agent = nil
+				end
+				if agent and agent.root and status.cwd and status.cwd ~= "" and status.cwd ~= agent.root then
+					agent = nil
+				end
 				if agent then
 					if status.state and agent.state ~= status.state then
 						agent.state = status.state
@@ -152,9 +167,14 @@ local function poll()
 						agent.session_id = status.session_id
 						changed = true
 					end
-					if status.title and status.title ~= "" and agent.title ~= status.title then
-						agent.title = status.title
-						changed = true
+					if status.title and status.title ~= "" then
+						-- titles come from lastPrompt and may contain newlines,
+						-- which nvim_buf_set_lines would reject
+						local title = status.title:gsub("\n", " ")
+						if agent.title ~= title then
+							agent.title = title
+							changed = true
+						end
 					end
 				end
 			end
@@ -174,7 +194,9 @@ local function start_timer()
 		1000,
 		2000,
 		vim.schedule_wrap(function()
-			if #M.agents == 0 then
+			-- stop once nothing alive remains (exited agents stay in the
+			-- registry but need no polling); spawn() restarts the timer
+			if #visible_agents() == 0 then
 				M._timer:stop()
 				M._timer:close()
 				M._timer = nil
@@ -419,7 +441,8 @@ function M.spawn(name, cmd)
 		return existing
 	end
 	local Terminal = require("toggleterm.terminal").Terminal
-	local agent = { name = name, state = "idle", title = "", session_id = nil, spawned_at = os.time() }
+	local root = project_root()
+	local agent = { name = name, state = "idle", title = "", session_id = nil, spawned_at = os.time(), root = root }
 	-- drop any stale status file from a previous life under the same name,
 	-- otherwise the poll would immediately mark the fresh agent with the
 	-- old state (e.g. "exited")
@@ -429,7 +452,7 @@ function M.spawn(name, cmd)
 		direction = "float",
 		count = next_count(),
 		display_name = name,
-		dir = project_root(),
+		dir = root,
 		env = { KIMI_AGENT_NAME = name },
 		on_exit = function()
 			agent.state = "exited"
@@ -527,7 +550,7 @@ function M.resume()
 		prompt = "Resume kimi session",
 		format_item = function(it)
 			local label = it.title ~= "" and it.title or it.id:sub(9, 24)
-			label = label:gsub("\n", " "):sub(1, 50)
+			label = vim.fn.strcharpart(label:gsub("\n", " "), 0, 50)
 			local when = it.mtime > 0 and os.date("%m-%d %H:%M", it.mtime) or "?"
 			return string.format("%s  (%s)", label, when)
 		end,
@@ -540,14 +563,21 @@ function M.resume()
 			M.toggle(open.name)
 			return
 		end
-		local name = (choice.title ~= "" and choice.title or choice.id:sub(9, 24)):gsub("\n", " "):sub(1, 30)
+		local name =
+			vim.fn.strcharpart((choice.title ~= "" and choice.title or choice.id:sub(9, 24)):gsub("\n", " "), 0, 30)
+		-- a live agent already holds this name: make it unique, otherwise
+		-- spawn() would just toggle that agent and we'd corrupt its
+		-- session_id/title below
+		if find(name) then
+			name = vim.fn.strcharpart(name, 0, 24) .. "-" .. choice.id:sub(9, 12)
+		end
 		local agent = M.spawn(name, "kimi --session " .. vim.fn.shellescape(choice.id))
 		if agent then
 			agent.session_id = choice.id
-			agent.title = choice.title:gsub("\n", " "):sub(1, 80)
-			-- the previous life of this session left an "exited" status file
-			-- behind (keyed by session id); drop it so the poll doesn't hide
-			-- the resumed agent
+			agent.title = vim.fn.strcharpart(choice.title:gsub("\n", " "), 0, 80)
+			-- sessions previously run outside nvim (no KIMI_AGENT_NAME) leave a
+			-- stale status file keyed by session id; the poll matches on
+			-- session id too, so drop it to keep the resumed agent visible
 			vim.fn.delete(STATUS_DIR .. "/" .. choice.id .. ".json")
 			refresh()
 		end

--- a/lua/lq/configs/agents.lua
+++ b/lua/lq/configs/agents.lua
@@ -367,6 +367,19 @@ function M.sidebar_toggle()
 			buffer = sb.buf,
 			callback = sidebar_highlight_current,
 		})
+		-- selection highlight only while the sidebar has focus
+		vim.api.nvim_create_autocmd({ "WinLeave", "BufLeave" }, {
+			buffer = sb.buf,
+			callback = function()
+				if vim.api.nvim_buf_is_valid(sb.buf) then
+					vim.api.nvim_buf_clear_namespace(sb.buf, NS_CURSOR, 0, -1)
+				end
+			end,
+		})
+		vim.api.nvim_create_autocmd({ "WinEnter", "BufEnter" }, {
+			buffer = sb.buf,
+			callback = sidebar_highlight_current,
+		})
 	end
 	vim.cmd("botright " .. SIDEBAR_WIDTH .. "vsplit")
 	sb.win = vim.api.nvim_get_current_win()

--- a/lua/lq/configs/agents.lua
+++ b/lua/lq/configs/agents.lua
@@ -270,6 +270,10 @@ function M.spawn(name, cmd)
 		return
 	end
 	name = sanitize(name)
+	if name == "" then
+		notify("agent name must not be empty", vim.log.levels.WARN)
+		return
+	end
 	local existing = find(name)
 	if existing then
 		M.toggle(name)
@@ -419,7 +423,7 @@ function M.resume()
 			return
 		end
 		local name = (choice.title ~= "" and choice.title or choice.id:sub(9, 24)):gsub("\n", " "):sub(1, 30)
-		local agent = M.spawn(name, "kimi --session " .. choice.id)
+		local agent = M.spawn(name, "kimi --session " .. vim.fn.shellescape(choice.id))
 		if agent then
 			agent.session_id = choice.id
 			agent.title = choice.title:gsub("\n", " "):sub(1, 80)

--- a/lua/lq/configs/agents.lua
+++ b/lua/lq/configs/agents.lua
@@ -70,6 +70,7 @@ vim.api.nvim_create_autocmd("ColorScheme", { callback = set_hls })
 M._last = nil ---@type string|nil
 M._next_count = 101
 M._timer = nil
+M._dead_sessions = {} ---@type table<string, boolean> session ids killed here; their hook writes are ignored
 M._sidebar = { buf = nil, win = nil, line_map = {}, block_map = {} }
 
 local function notify(msg, level)
@@ -137,11 +138,17 @@ local function poll()
 		if ok and lines[1] then
 			local ok2, status = pcall(vim.json.decode, table.concat(lines, "\n"))
 			if ok2 and type(status) == "table" then
+				-- tombstoned sessions (killed here) must never update anything:
+				-- a killed agent's late hook writes can otherwise leak into a
+				-- same-named respawn whose session_id isn't known yet
+				if status.session_id and M._dead_sessions[status.session_id] then
+					goto continue
+				end
 				local agent = (status.name and find(status.name))
 					or (status.session_id and find_by_session(status.session_id))
-				-- ignore status written before this agent was spawned (stale
+				-- ignore status written no later than this agent's spawn (stale
 				-- file from a previous life under the same name/session)
-				if agent and status.ts and agent.spawned_at and status.ts < agent.spawned_at then
+				if agent and status.ts and agent.spawned_at and status.ts <= agent.spawned_at then
 					agent = nil
 				end
 				-- ignore status from a different session or a different project
@@ -179,6 +186,7 @@ local function poll()
 				end
 			end
 		end
+		::continue::
 	end
 	if changed then
 		refresh()
@@ -499,6 +507,11 @@ function M.kill(name, force)
 		return
 	end
 	agent.term:shutdown()
+	-- tombstone the session so its late hook writes (SessionEnd fires on
+	-- shutdown) can't leak into a future same-named agent
+	if agent.session_id then
+		M._dead_sessions[agent.session_id] = true
+	end
 	table.remove(M.agents, idx)
 	if M._last == name then
 		M._last = nil
@@ -569,11 +582,19 @@ function M.resume()
 		-- spawn() would just toggle that agent and we'd corrupt its
 		-- session_id/title below
 		if find(name) then
-			name = vim.fn.strcharpart(name, 0, 24) .. "-" .. choice.id:sub(9, 12)
+			local base = vim.fn.strcharpart(name, 0, 24)
+			name = base .. "-" .. choice.id:sub(9, 16)
+			local n = 2
+			while find(name) do
+				name = base .. "-" .. n
+				n = n + 1
+			end
 		end
 		local agent = M.spawn(name, "kimi --session " .. vim.fn.shellescape(choice.id))
 		if agent then
 			agent.session_id = choice.id
+			-- a previously killed session may be tombstoned; resurrect it
+			M._dead_sessions[choice.id] = nil
 			agent.title = vim.fn.strcharpart(choice.title:gsub("\n", " "), 0, 80)
 			-- sessions previously run outside nvim (no KIMI_AGENT_NAME) leave a
 			-- stale status file keyed by session id; the poll matches on

--- a/lua/lq/configs/heirline/components.lua
+++ b/lua/lq/configs/heirline/components.lua
@@ -194,59 +194,62 @@ M.Space = { provider = " " }
 -- M.FileName = { provider = "%f" }
 
 local FileNameBlock = {
-    -- let's first set up some attributes needed by this component and it's children
-    init = function(self)
-        self.filename = vim.api.nvim_buf_get_name(0)
-    end,
+	-- let's first set up some attributes needed by this component and it's children
+	init = function(self)
+		self.filename = vim.api.nvim_buf_get_name(0)
+	end,
 }
 -- We can now define some children separately and add them later
 
 local FileIcon = {
-    init = function(self)
-        local filename = self.filename
-        local extension = vim.fn.fnamemodify(filename, ":e")
-        self.icon, self.icon_color = require("nvim-web-devicons").get_icon_color(filename, extension, { default = true })
-    end,
-    provider = function(self)
-        return self.icon and (self.icon .. " ")
-    end,
-    hl = function(self)
-        return { fg = self.icon_color }
-    end
+	init = function(self)
+		local filename = self.filename
+		local extension = vim.fn.fnamemodify(filename, ":e")
+		self.icon, self.icon_color =
+			require("nvim-web-devicons").get_icon_color(filename, extension, { default = true })
+	end,
+	provider = function(self)
+		return self.icon and (self.icon .. " ")
+	end,
+	hl = function(self)
+		return { fg = self.icon_color }
+	end,
 }
 
 local FileName = {
-    provider = function(self)
-        -- first, trim the pattern relative to the current directory. For other
-        -- options, see :h filename-modifers
-        local filename = vim.fn.fnamemodify(self.filename, ":.")
-        if filename == "" then return "[No Name]" end
-        -- now, if the filename would occupy more than 1/4th of the available
-        -- space, we trim the file path to its initials
-        -- See Flexible Components section below for dynamic truncation
-        if not conditions.width_percent_below(#filename, 0.4) then
-            filename = vim.fn.pathshorten(filename)
-        end
-        return filename
-    end,
-    hl = { fg = utils.get_highlight("Directory").fg },
+	provider = function(self)
+		-- first, trim the pattern relative to the current directory. For other
+		-- options, see :h filename-modifers
+		local filename = vim.fn.fnamemodify(self.filename, ":.")
+		if filename == "" then
+			return "[No Name]"
+		end
+		-- now, if the filename would occupy more than 1/4th of the available
+		-- space, we trim the file path to its initials
+		-- See Flexible Components section below for dynamic truncation
+		if not conditions.width_percent_below(#filename, 0.4) then
+			filename = vim.fn.pathshorten(filename)
+		end
+		return filename
+	end,
+	hl = { fg = utils.get_highlight("Directory").fg },
 }
 
 local FileFlags = {
-    {
-        condition = function()
-            return vim.bo.modified
-        end,
-        provider = " ●",
-        hl = { fg = "#99FF66" },
-    },
-    {
-        condition = function()
-            return not vim.bo.modifiable or vim.bo.readonly
-        end,
-        provider = " ",
-        hl = { fg = "orange" },
-    },
+	{
+		condition = function()
+			return vim.bo.modified
+		end,
+		provider = " ●",
+		hl = { fg = "#99FF66" },
+	},
+	{
+		condition = function()
+			return not vim.bo.modifiable or vim.bo.readonly
+		end,
+		provider = " ",
+		hl = { fg = "orange" },
+	},
 }
 
 -- Now, let's say that we want the filename color to change if the buffer is
@@ -255,23 +258,24 @@ local FileFlags = {
 -- component
 
 local FileNameModifer = {
-    hl = function()
-        if vim.bo.modified then
-            -- use `force` because we need to override the child's hl foreground
-            return { fg = "cyan", bold = true, force=true }
-        end
-    end,
+	hl = function()
+		if vim.bo.modified then
+			-- use `force` because we need to override the child's hl foreground
+			return { fg = "cyan", bold = true, force = true }
+		end
+	end,
 }
 
 -- let's add the children to our FileNameBlock component
-M.FileNameBlock = utils.insert(FileNameBlock,
-    FileIcon,
-    FileName,
-    -- utils.insert(FileNameModifer, FileName), -- a new table where FileName is a child of FileNameModifier
-    FileFlags,
-    { provider = '%<'} -- this means that the statusline is cut here when there's not enough space
+M.FileNameBlock = utils.insert(
+	FileNameBlock,
+	FileIcon,
+	FileName,
+	-- utils.insert(FileNameModifer, FileName), -- a new table where FileName is a child of FileNameModifier
+	FileFlags,
+	{ provider = "%<" } -- this means that the statusline is cut here when there's not enough space
 )
--- kimi agent manager status: "  agents running/total" while live agents exist
+-- kimi agent manager status: " 🤖 running/total" while live agents exist
 M.Agents = {
 	condition = function()
 		local ok, agents = pcall(require, "lq.configs.agents")
@@ -282,7 +286,7 @@ M.Agents = {
 		self.running, self.total = agents.status()
 	end,
 	provider = function(self)
-		return string.format("   agents %d/%d ", self.running, self.total)
+		return string.format(" 🤖 %d/%d ", self.running, self.total)
 	end,
 	hl = function(self)
 		return { fg = self.running > 0 and colors.orange or colors.green, bg = "#1f2335" }

--- a/lua/lq/configs/heirline/components.lua
+++ b/lua/lq/configs/heirline/components.lua
@@ -271,7 +271,7 @@ M.FileNameBlock = utils.insert(FileNameBlock,
     FileFlags,
     { provider = '%<'} -- this means that the statusline is cut here when there's not enough space
 )
--- kimi agent manager status: "● running/total" while agents exist
+-- kimi agent manager status: "  agents running/total" while live agents exist
 M.Agents = {
 	condition = function()
 		local ok, agents = pcall(require, "lq.configs.agents")
@@ -282,10 +282,10 @@ M.Agents = {
 		self.running, self.total = agents.status()
 	end,
 	provider = function(self)
-		return string.format("  %d/%d ", self.running, self.total)
+		return string.format("   agents %d/%d ", self.running, self.total)
 	end,
 	hl = function(self)
-		return { fg = self.running > 0 and colors.orange or colors.gray, bg = "#1f2335" }
+		return { fg = self.running > 0 and colors.orange or colors.green, bg = "#1f2335" }
 	end,
 }
 

--- a/lua/lq/configs/heirline/components.lua
+++ b/lua/lq/configs/heirline/components.lua
@@ -271,4 +271,22 @@ M.FileNameBlock = utils.insert(FileNameBlock,
     FileFlags,
     { provider = '%<'} -- this means that the statusline is cut here when there's not enough space
 )
+-- kimi agent manager status: "● running/total" while agents exist
+M.Agents = {
+	condition = function()
+		local ok, agents = pcall(require, "lq.configs.agents")
+		return ok and agents.count() > 0
+	end,
+	init = function(self)
+		local agents = require("lq.configs.agents")
+		self.running, self.total = agents.status()
+	end,
+	provider = function(self)
+		return string.format("  %d/%d ", self.running, self.total)
+	end,
+	hl = function(self)
+		return { fg = self.running > 0 and colors.orange or colors.gray, bg = "#1f2335" }
+	end,
+}
+
 return M

--- a/lua/lq/configs/heirline/init.lua
+++ b/lua/lq/configs/heirline/init.lua
@@ -10,10 +10,10 @@ local statusline = {
 	component.Diagnostics,
 	component.Space,
 	component.Space,
+	component.Agents,
 	component.LSP,
 	component.Treesitter,
 	component.Ruler,
-	component.Agents,
 	-- component.ScrollBar,
 }
 require("heirline").setup({statusline=statusline})

--- a/lua/lq/configs/heirline/init.lua
+++ b/lua/lq/configs/heirline/init.lua
@@ -12,8 +12,8 @@ local statusline = {
 	component.Space,
 	component.LSP,
 	component.Treesitter,
-	component.Agents,
 	component.Ruler,
+	component.Agents,
 	-- component.ScrollBar,
 }
 require("heirline").setup({statusline=statusline})

--- a/lua/lq/configs/heirline/init.lua
+++ b/lua/lq/configs/heirline/init.lua
@@ -12,6 +12,7 @@ local statusline = {
 	component.Space,
 	component.LSP,
 	component.Treesitter,
+	component.Agents,
 	component.Ruler,
 	-- component.ScrollBar,
 }

--- a/lua/lq/configs/terminal.lua
+++ b/lua/lq/configs/terminal.lua
@@ -49,7 +49,7 @@ local terminal_opts = {
 	-- laughing.builtin.terminal.execs[#laughing.builtin.terminal.execs+1] = {"gdb", "tg", "GNU Debugger"}
 	execs = {
 		{ "lazygit", "<leader>gg", "LazyGit", "float" },
-		{ "kimi --continue", "<leader>K", "kimi", "float" },
+		-- kimi agents are managed dynamically by lq.configs.agents (<leader>K*)
 	},
 }
 

--- a/lua/lq/configs/terminal.lua
+++ b/lua/lq/configs/terminal.lua
@@ -49,7 +49,7 @@ local terminal_opts = {
 	-- laughing.builtin.terminal.execs[#laughing.builtin.terminal.execs+1] = {"gdb", "tg", "GNU Debugger"}
 	execs = {
 		{ "lazygit", "<leader>gg", "LazyGit", "float" },
-		-- kimi agents are managed dynamically by lq.configs.agents (<leader>K*)
+		-- kimi agents are managed dynamically by lq.configs.agents (<leader>k*)
 	},
 }
 

--- a/lua/lq/configs/which-key.lua
+++ b/lua/lq/configs/which-key.lua
@@ -72,6 +72,9 @@ leader_key = {
 			remap = false,
 		},
 
+		-- kimi agent manager (bindings in lq.configs.agents)
+		{ "<leader>K", group = "kimi agents", nowait = true, remap = false },
+
 		-- fold
 		{ "<leader>o", "za", desc = "Fold", nowait = true, remap = false },
 		-- Compile file

--- a/lua/lq/configs/which-key.lua
+++ b/lua/lq/configs/which-key.lua
@@ -73,7 +73,9 @@ leader_key = {
 		},
 
 		-- kimi agent manager (bindings in lq.configs.agents)
-		{ "<leader>K", group = "kimi agents", nowait = true, remap = false },
+		{ "<leader>k", group = "kimi agents", nowait = true, remap = false },
+		-- CopilotChat (bindings in plugin/keymappings.lua)
+		{ "<leader>K", group = "CopilotChat", nowait = true, remap = false },
 
 		-- fold
 		{ "<leader>o", "za", desc = "Fold", nowait = true, remap = false },

--- a/lua/lq/plugins/basic.lua
+++ b/lua/lq/plugins/basic.lua
@@ -29,6 +29,7 @@ return {
 		event = "VeryLazy",
 		config = function()
 			require("lq.configs.terminal").setup()
+			require("lq.configs.agents").setup()
 		end,
 	},
 

--- a/plugin/keymappings.lua
+++ b/plugin/keymappings.lua
@@ -150,26 +150,26 @@ map("n", "gr", ":Lspsaga finder<CR>")
 map("n", "gD", ":vsplit<CR>:lua vim.lsp.buf.definition()<CR>")
 
 -- copliot
-map("n", "<leader>kk", "<cmd>CopilotChat<CR>", { desc = "CopilotChat", nowait = true, remap = false })
+map("n", "<leader>Kk", "<cmd>CopilotChat<CR>", { desc = "CopilotChat", nowait = true, remap = false })
 map(
 	{ "v", "n" },
-	"<leader>ke",
+	"<leader>Ke",
 	"<cmd>CopilotChatExplain<CR>",
 	{ desc = "CopilotExplain", nowait = true, remap = false }
 )
-map({ "v", "n" }, "<leader>kr", "<cmd>CopilotChatReview<CR>", { desc = "CopilotReview", nowait = true, remap = false })
-map({ "v", "n" }, "<leader>kf", "<cmd>CopilotChatFix<CR>", { desc = "CopilotFix", nowait = true, remap = false })
+map({ "v", "n" }, "<leader>Kr", "<cmd>CopilotChatReview<CR>", { desc = "CopilotReview", nowait = true, remap = false })
+map({ "v", "n" }, "<leader>Kf", "<cmd>CopilotChatFix<CR>", { desc = "CopilotFix", nowait = true, remap = false })
 map(
 	{ "v", "n" },
-	"<leader>ko",
+	"<leader>Ko",
 	"<cmd>CopilotChatOptimize<CR>",
 	{ desc = "CopilotOptimize", nowait = true, remap = false }
 )
-map({ "v", "n" }, "<leader>kd", "<cmd>CopilotChatDocs<CR>", { desc = "CopilotDocs", nowait = true, remap = false })
-map({ "v", "n" }, "<leader>kt", "<cmd>CopilotChatTests<CR>", { desc = "CopilotTests", nowait = true, remap = false })
+map({ "v", "n" }, "<leader>Kd", "<cmd>CopilotChatDocs<CR>", { desc = "CopilotDocs", nowait = true, remap = false })
+map({ "v", "n" }, "<leader>Kt", "<cmd>CopilotChatTests<CR>", { desc = "CopilotTests", nowait = true, remap = false })
 map(
 	{ "v", "n" },
-	"<leader>kc",
+	"<leader>Kc",
 	"<cmd>CopilotChatCommit<CR>",
 	{ desc = "CopilotCommitInfo", nowait = true, remap = false }
 )

--- a/scripts/agent-status.sh
+++ b/scripts/agent-status.sh
@@ -18,6 +18,7 @@ cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty')"
 
 # Agents spawned from Neovim carry KIMI_AGENT_NAME; fall back to the session id.
 name="${KIMI_AGENT_NAME:-$session_id}"
+name="$(printf '%s' "$name" | sed 's#[/\\]#-#g; s/^[[:space:]]*//; s/[[:space:]]*$//')"
 [ -n "$name" ] || exit 0
 
 # Best-effort title: session_index.jsonl maps sessionId -> sessionDir, and
@@ -30,6 +31,8 @@ if [ -n "$session_id" ] && [ -f "$kimi_home/session_index.jsonl" ]; then
 	fi
 fi
 
+tmp_file="$(mktemp "$status_dir/.agent-status.XXXXXX")"
+trap 'rm -f "$tmp_file"' EXIT
 jq -n \
 	--arg name "$name" \
 	--arg session_id "$session_id" \
@@ -38,5 +41,5 @@ jq -n \
 	--arg cwd "$cwd" \
 	--argjson ts "$(date +%s)" \
 	'{name: $name, session_id: $session_id, state: $state, title: $title, cwd: $cwd, ts: $ts}' \
-	> "$status_dir/$name.json.tmp"
-mv -f "$status_dir/$name.json.tmp" "$status_dir/$name.json"
+	> "$tmp_file"
+mv -f "$tmp_file" "$status_dir/$name.json"

--- a/scripts/agent-status.sh
+++ b/scripts/agent-status.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# kimi-code hook: record per-agent status for the Neovim agent manager
+# (lua/lq/configs/agents.lua). Called from [[hooks]] entries in
+# $KIMI_CODE_HOME/config.toml with the new state as $1, e.g.:
+#   command = "~/.config/nvim/scripts/agent-status.sh running"
+# The CLI passes a JSON payload on stdin: { "hook_event_name", "session_id", "cwd", ... }.
+set -euo pipefail
+
+state="${1:?usage: agent-status.sh <running|idle|interrupted|exited>}"
+
+kimi_home="${KIMI_CODE_HOME:-$HOME/.kimi-code}"
+status_dir="$kimi_home/agent-status"
+mkdir -p "$status_dir"
+
+payload="$(cat)"
+session_id="$(printf '%s' "$payload" | jq -r '.session_id // empty')"
+cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty')"
+
+# Agents spawned from Neovim carry KIMI_AGENT_NAME; fall back to the session id.
+name="${KIMI_AGENT_NAME:-$session_id}"
+[ -n "$name" ] || exit 0
+
+# Best-effort title: session_index.jsonl maps sessionId -> sessionDir, and
+# <sessionDir>/state.json holds the title (read-only; never edit session files).
+title=""
+if [ -n "$session_id" ] && [ -f "$kimi_home/session_index.jsonl" ]; then
+	session_dir="$(jq -r --arg id "$session_id" 'select(.sessionId == $id) | .sessionDir' "$kimi_home/session_index.jsonl" | tail -1)"
+	if [ -n "$session_dir" ] && [ -f "$session_dir/state.json" ]; then
+		title="$(jq -r '.title // empty' "$session_dir/state.json")"
+	fi
+fi
+
+jq -n \
+	--arg name "$name" \
+	--arg session_id "$session_id" \
+	--arg state "$state" \
+	--arg title "$title" \
+	--arg cwd "$cwd" \
+	--argjson ts "$(date +%s)" \
+	'{name: $name, session_id: $session_id, state: $state, title: $title, cwd: $cwd, ts: $ts}' \
+	> "$status_dir/$name.json.tmp"
+mv -f "$status_dir/$name.json.tmp" "$status_dir/$name.json"


### PR DESCRIPTION
## What

Manage multiple named [kimi-code](https://github.com/MoonshotAI/kimi-code) CLI sessions inside Neovim, instead of the single fixed-slot `kimi --continue` toggleterm exec.

- **`lua/lq/configs/agents.lua`** — agent registry on top of toggleterm: each agent is a named float terminal running `kimi`. Keymaps:
  - `<leader>K` toggle last-active agent, `<leader>Kn` new named agent, `<leader>Kr` resume an existing kimi session (picked from `session_index.jsonl`, with titles and timestamps), `<leader>Kl` pick agent, `<leader>Kx` kill agent
  - `<leader>Ka` toggles a **sidebar** listing all agents with live state (● running / ○ idle / ◐ interrupted / ✕ exited), session title, and a preview of the last output lines; buffer maps: `<CR>` toggle float, `d` kill, `n` new, `r` resume, `q` close
- **heirline** — new `● running/total` component in the statusline.
- **`scripts/agent-status.sh`** — kimi-code hook script; states come from hook events (`UserPromptSubmit`/`Stop`/`Interrupt`/`SessionEnd`), polled from `$KIMI_CODE_HOME/agent-status/*.json` every 2s.
- Agent terminals pin `dir` to the git root at spawn, fixing the non-deterministic cwd caused by the `BufEnter lcd %:p:h` autocmd.

## Required manual setup (outside this repo)

Append to `$KIMI_CODE_HOME/config.toml`:

```toml
[[hooks]]
event = "UserPromptSubmit"
command = "~/.config/nvim/scripts/agent-status.sh running"

[[hooks]]
event = "Stop"
command = "~/.config/nvim/scripts/agent-status.sh idle"

[[hooks]]
event = "Interrupt"
command = "~/.config/nvim/scripts/agent-status.sh interrupted"

[[hooks]]
event = "SessionEnd"
command = "~/.config/nvim/scripts/agent-status.sh exited"
```

## Verification

- Headless test suite (spawn/dedup/kill/sidebar/statusline/polling): PASS
- Live hook smoke test (`kimi -p` with `KIMI_AGENT_NAME` set): status JSON written with correct name/session/title/state; `kimi doctor` passes
- Reviewed by codex CLI; its fixes (empty-name guard, shellescape, name sanitization, atomic status writes) included in the last commit

## Not included (future)

- Persistence across Neovim restarts (would need tmux)
- Real-time push updates (2s polling by design)

## Review discussion (codex CLI, 4 rounds)

Reviewed in read-only mode across 4 rounds; verdict went from "not merge-ready" to **"merge-ready with documented limitations"**. Fixed along the way: timer lifecycle, cross-project status corruption (cwd match), multiline titles, UTF-8 truncation, resume name collisions, stale-status races (session-id match, spawn-time guard, kill tombstones).

Accepted limitation (documented in `agents.lua` above `poll()`): killing an agent within ~2s of spawn — before its session id is known — can briefly leak a stale state into an immediate same-named respawn; self-heals on the next hook event.
