### PR TITLE
Persist agents across restarts + name kimi sessions after agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,42 @@ cd ~/.config/nvim
 ./install.sh
 ```
 
+## Kimi agent manager🤖
+Manage multiple [kimi-code](https://github.com/MoonshotAI/kimi-code) CLI agents inside neovim: named agents in float terminals, a sidebar listing them with live status (`<leader>ka`), a `🤖 running/total` statusline component, and per-project agent persistence across neovim restarts.
+
+Requirements: [kimi-code CLI](https://moonshotai.github.io/kimi-code/en/) and `jq`.
+
+Agent status (running/idle/interrupted/exited) is reported by kimi-code [hooks](https://moonshotai.github.io/kimi-code/en/customization/hooks.html) via [scripts/agent-status.sh](./scripts/agent-status.sh). To enable it, append this to your kimi-code config (`$KIMI_CODE_HOME/config.toml`, default `~/.kimi-code/config.toml`):
+
+```toml
+[[hooks]]
+event = "UserPromptSubmit"
+command = "~/.config/nvim/scripts/agent-status.sh running"
+
+[[hooks]]
+event = "Stop"
+command = "~/.config/nvim/scripts/agent-status.sh idle"
+
+[[hooks]]
+event = "Interrupt"
+command = "~/.config/nvim/scripts/agent-status.sh interrupted"
+
+[[hooks]]
+event = "SessionEnd"
+command = "~/.config/nvim/scripts/agent-status.sh exited"
+```
+
+Validate with `kimi doctor`. Without these hooks everything still works, but agents will always show as `idle`.
+
+| shortcut          | action                                 | mode |
+|-------------------|----------------------------------------|------|
+| `<leader>` `k`    | toggle last active agent float         | `n`  |
+| `<leader>` `k` `n`| new named agent                        | `n`  |
+| `<leader>` `k` `r`| resume an existing kimi session        | `n`  |
+| `<leader>` `k` `a`| toggle the agents sidebar              | `n`  |
+
+Sidebar buffer mappings: `<CR>` toggle agent float, `i`/`k` jump between agents, `n` new, `r` resume, `d`/`x` kill, `q` close.
+
 ## Screenshots🖼️
 ![demo1](https://user-images.githubusercontent.com/61612323/153551187-156189ea-9e52-407c-8888-743439f5bf4c.png)
 ![demo2](https://user-images.githubusercontent.com/61612323/153551199-e7c6896f-a125-4622-ab19-03277cd32a28.png)

--- a/lua/lq/configs/agents.lua
+++ b/lua/lq/configs/agents.lua
@@ -29,6 +29,7 @@ local M = {}
 ---@field spawned_at integer|nil os.time() at terminal creation, used to ignore stale status files
 ---@field root string|nil project root at spawn, used to ignore status from other projects
 ---@field _want_title boolean|nil pending /title send (fresh and restored agents)
+---@field _suppress_exit boolean|nil restored agents: ignore "exited" until the first live status
 
 ---@type KimiAgent[]
 M.agents = {}
@@ -179,19 +180,27 @@ local function poll()
 					agent = nil
 				end
 				if agent then
-					-- a restored agent without a terminal yet must not be
-					-- hidden by a stale "exited" (fired when the previous nvim
-					-- killed the session): it stays resumable in the sidebar
+					-- a restored agent must not be hidden by a stale "exited"
+					-- (written when the previous nvim killed the session): it
+					-- stays resumable in the sidebar. The suppression holds
+					-- until the first live (non-exited) status arrives after
+					-- resume; genuine exits are covered by on_exit instead.
 					local new_state = status.state
-					if new_state == "exited" and not agent.term then
+					if new_state == "exited" and (not agent.term or agent._suppress_exit) then
 						new_state = nil
 					end
 					if new_state and agent.state ~= new_state then
 						agent.state = new_state
+						if new_state ~= "exited" then
+							agent._suppress_exit = nil
+						end
 						changed = true
 					end
 					if status.session_id and status.session_id ~= "" and not agent.session_id then
 						agent.session_id = status.session_id
+						-- persist right away; without this a crash before
+						-- VimLeavePre would lose the agent
+						M.save_registry()
 						changed = true
 					end
 					if status.title and status.title ~= "" then
@@ -209,7 +218,7 @@ local function poll()
 					if
 						agent._want_title
 						and agent.session_id
-						and agent.state ~= "running"
+						and (agent.state == "idle" or agent.state == "interrupted")
 						and agent.term
 						and agent.term.job_id
 					then
@@ -217,11 +226,17 @@ local function poll()
 						-- raw chansend: term:send would steal window focus. Text
 						-- and Enter must go in separate chunks — in one chunk the
 						-- TUI drops the Enter (verified experimentally).
-						vim.api.nvim_chan_send(agent.term.job_id, "/title " .. agent.name)
-						vim.defer_fn(function()
-							if agent.term and agent.term.job_id then
-								vim.api.nvim_chan_send(agent.term.job_id, "\r")
+						local job = agent.term.job_id
+						local function send(chunk)
+							-- the agent may have been killed since; send only if
+							-- the same agent is registered and the job is alive
+							if find(agent.name) == agent and vim.fn.jobwait({ job }, 0)[1] == -1 then
+								pcall(vim.api.nvim_chan_send, job, chunk)
 							end
+						end
+						send("/title " .. agent.name)
+						vim.defer_fn(function()
+							send("\r")
 						end, 300)
 					end
 				end
@@ -265,30 +280,82 @@ local function registry_path(root)
 	return REGISTRY_DIR .. "/" .. vim.fn.sha256(root):sub(1, 16) .. ".json"
 end
 
----Persist this project's live agents so they reappear on the next nvim
----start. Agents without a known session id are skipped: kimi creates
----sessions lazily on the first prompt, so an agent that never got one has
----no session to resume.
-function M.save_registry()
-	local root = project_root()
-	local out = {}
-	for _, a in ipairs(M.agents) do
-		if a.state ~= "exited" and a.session_id and a.root == root then
-			table.insert(out, { name = a.name, session_id = a.session_id, title = a.title })
+---Type-check a registry entry (from disk or built locally).
+local function valid_entry(e)
+	return type(e) == "table"
+		and type(e.name) == "string"
+		and type(e.session_id) == "string"
+		and (e.title == nil or type(e.title) == "string")
+end
+
+---Write one project's registry file: merge what is on disk (so concurrent
+---nvim instances of the same project don't clobber each other) with the
+---local registry (local state wins; locally exited/tombstoned sessions are
+---dropped), then write atomically via tmp + rename.
+local function write_registry(root)
+	local path = registry_path(root)
+	local merged = {}
+	local f = io.open(path, "r")
+	if f then
+		local ok, data = pcall(vim.json.decode, f:read("*a"))
+		f:close()
+		if ok and type(data) == "table" and type(data.agents) == "table" then
+			for _, e in ipairs(data.agents) do
+				if valid_entry(e) and not M._dead_sessions[e.session_id] then
+					merged[e.session_id] = { name = e.name, session_id = e.session_id, title = e.title or "" }
+				end
+			end
 		end
 	end
-	local path = registry_path(root)
+	for _, a in ipairs(M.agents) do
+		if a.session_id and a.root == root then
+			if a.state ~= "exited" then
+				merged[a.session_id] = { name = a.name, session_id = a.session_id, title = a.title }
+			else
+				merged[a.session_id] = nil
+			end
+		end
+	end
+	local out = {}
+	for _, e in pairs(merged) do
+		table.insert(out, e)
+	end
 	if #out == 0 then
 		vim.fn.delete(path)
 		return
 	end
 	vim.fn.mkdir(REGISTRY_DIR, "p")
-	local f = io.open(path, "w")
-	if not f then
+	local tmp = path .. ".tmp"
+	local wf = io.open(tmp, "w")
+	if not wf then
+		notify("failed to write agent registry " .. path, vim.log.levels.WARN)
 		return
 	end
-	f:write(vim.json.encode({ agents = out }))
-	f:close()
+	wf:write(vim.json.encode({ agents = out }))
+	wf:close()
+	local ok, err = vim.uv.fs_rename(tmp, path)
+	if not ok then
+		notify("failed to replace agent registry: " .. tostring(err), vim.log.levels.WARN)
+		vim.fn.delete(tmp)
+	end
+end
+
+---Persist live agents so they reappear on the next nvim start, once per
+---project root covered by the registry (agents can be rooted in different
+---projects when spawned while a buffer of another project is focused).
+---Agents without a known session id are skipped: kimi creates sessions
+---lazily on the first prompt, so an agent that never got one has no session
+---to resume.
+function M.save_registry()
+	local roots = { [project_root()] = true }
+	for _, a in ipairs(M.agents) do
+		if a.root then
+			roots[a.root] = true
+		end
+	end
+	for root in pairs(roots) do
+		write_registry(root)
+	end
 end
 
 ---Re-register agents saved by a previous nvim session of this project.
@@ -306,7 +373,7 @@ function M.restore_registry()
 	end
 	local restored = 0
 	for _, e in ipairs(data.agents) do
-		if e.name and e.session_id and not find(e.name) then
+		if valid_entry(e) and not find(e.name) then
 			table.insert(M.agents, {
 				name = e.name,
 				term = nil,
@@ -316,6 +383,8 @@ function M.restore_registry()
 				session_id = e.session_id,
 				spawned_at = nil,
 				root = root,
+				-- ignore stale "exited" writes until a live status arrives
+				_suppress_exit = true,
 				-- also name sessions restored from before /title existed
 				_want_title = true,
 			})

--- a/lua/lq/configs/agents.lua
+++ b/lua/lq/configs/agents.lua
@@ -179,8 +179,15 @@ local function poll()
 					agent = nil
 				end
 				if agent then
-					if status.state and agent.state ~= status.state then
-						agent.state = status.state
+					-- a restored agent without a terminal yet must not be
+					-- hidden by a stale "exited" (fired when the previous nvim
+					-- killed the session): it stays resumable in the sidebar
+					local new_state = status.state
+					if new_state == "exited" and not agent.term then
+						new_state = nil
+					end
+					if new_state and agent.state ~= new_state then
+						agent.state = new_state
 						changed = true
 					end
 					if status.session_id and status.session_id ~= "" and not agent.session_id then
@@ -226,6 +233,9 @@ local function poll()
 		refresh()
 	end
 end
+
+-- exposed for the headless test suite
+M._poll = poll
 
 local function start_timer()
 	if M._timer then

--- a/lua/lq/configs/agents.lua
+++ b/lua/lq/configs/agents.lua
@@ -7,6 +7,11 @@
 -- Exited agents stay in the registry (so their float can still be toggled)
 -- but are hidden from the sidebar, picker and statusline.
 --
+-- Persistence: live agents (with a known session id) are saved per project
+-- to $KIMI_CODE_HOME/agent-registry/<hash>.json on spawn/kill/exit and
+-- VimLeavePre, and restored on setup. Restored agents have no terminal yet;
+-- it is spawned lazily on first toggle via `kimi --session <id>`.
+--
 -- UI notes: all colors come from semantic highlight links (Diagnostic* for
 -- states, Title/Comment/CursorLine for chrome) so the sidebar follows the
 -- active colorscheme; groups are namespaced KimiAgents* and re-applied on
@@ -16,12 +21,14 @@ local M = {}
 
 ---@class KimiAgent
 ---@field name string
----@field term table toggleterm Terminal
+---@field term table|nil toggleterm Terminal (nil until first toggle for restored agents)
+---@field cmd string|nil terminal command (nil means plain "kimi")
 ---@field state "running"|"idle"|"interrupted"|"exited"
 ---@field title string
 ---@field session_id string|nil
----@field spawned_at integer|nil os.time() at spawn, used to ignore stale status files
+---@field spawned_at integer|nil os.time() at terminal creation, used to ignore stale status files
 ---@field root string|nil project root at spawn, used to ignore status from other projects
+---@field _want_title boolean|nil pending /title send (fresh and restored agents)
 
 ---@type KimiAgent[]
 M.agents = {}
@@ -29,6 +36,7 @@ M.agents = {}
 local KIMI_HOME = vim.env.KIMI_CODE_HOME or (vim.fn.expand("~/.kimi-code"))
 local STATUS_DIR = KIMI_HOME .. "/agent-status"
 local INDEX_FILE = KIMI_HOME .. "/session_index.jsonl"
+local REGISTRY_DIR = KIMI_HOME .. "/agent-registry"
 
 local NS_STATE = vim.api.nvim_create_namespace("kimi_agents_state")
 local NS_CURSOR = vim.api.nvim_create_namespace("kimi_agents_cursor")
@@ -188,6 +196,27 @@ local function poll()
 							changed = true
 						end
 					end
+					-- name the kimi session itself. Sessions are created lazily
+					-- on the first prompt and /title only works while the agent
+					-- is idle, so this must wait for the first turn to end.
+					if
+						agent._want_title
+						and agent.session_id
+						and agent.state ~= "running"
+						and agent.term
+						and agent.term.job_id
+					then
+						agent._want_title = false
+						-- raw chansend: term:send would steal window focus. Text
+						-- and Enter must go in separate chunks — in one chunk the
+						-- TUI drops the Enter (verified experimentally).
+						vim.api.nvim_chan_send(agent.term.job_id, "/title " .. agent.name)
+						vim.defer_fn(function()
+							if agent.term and agent.term.job_id then
+								vim.api.nvim_chan_send(agent.term.job_id, "\r")
+							end
+						end, 300)
+					end
 				end
 			end
 		end
@@ -220,6 +249,77 @@ local function start_timer()
 	)
 end
 
+-- ------------------------------------------------------------ persistence --
+
+local function registry_path(root)
+	return REGISTRY_DIR .. "/" .. vim.fn.sha256(root):sub(1, 16) .. ".json"
+end
+
+---Persist this project's live agents so they reappear on the next nvim
+---start. Agents without a known session id are skipped: kimi creates
+---sessions lazily on the first prompt, so an agent that never got one has
+---no session to resume.
+function M.save_registry()
+	local root = project_root()
+	local out = {}
+	for _, a in ipairs(M.agents) do
+		if a.state ~= "exited" and a.session_id and a.root == root then
+			table.insert(out, { name = a.name, session_id = a.session_id, title = a.title })
+		end
+	end
+	local path = registry_path(root)
+	if #out == 0 then
+		vim.fn.delete(path)
+		return
+	end
+	vim.fn.mkdir(REGISTRY_DIR, "p")
+	local f = io.open(path, "w")
+	if not f then
+		return
+	end
+	f:write(vim.json.encode({ agents = out }))
+	f:close()
+end
+
+---Re-register agents saved by a previous nvim session of this project.
+---No terminals are spawned here; each agent resumes lazily on first toggle.
+function M.restore_registry()
+	local root = project_root()
+	local f = io.open(registry_path(root), "r")
+	if not f then
+		return
+	end
+	local ok, data = pcall(vim.json.decode, f:read("*a"))
+	f:close()
+	if not ok or type(data) ~= "table" or type(data.agents) ~= "table" then
+		return
+	end
+	local restored = 0
+	for _, e in ipairs(data.agents) do
+		if e.name and e.session_id and not find(e.name) then
+			table.insert(M.agents, {
+				name = e.name,
+				term = nil,
+				cmd = "kimi --session " .. vim.fn.shellescape(e.session_id),
+				state = "idle",
+				title = e.title or "",
+				session_id = e.session_id,
+				spawned_at = nil,
+				root = root,
+				-- also name sessions restored from before /title existed
+				_want_title = true,
+			})
+			restored = restored + 1
+		end
+	end
+	if restored > 0 then
+		M._last = M.agents[#M.agents].name
+		start_timer()
+		refresh()
+		notify(restored .. " agent(s) restored — <CR> in the sidebar to resume")
+	end
+end
+
 -- ---------------------------------------------------------------- sidebar --
 
 local SIDEBAR_WIDTH = 42
@@ -227,7 +327,7 @@ local PREVIEW_LINES = 2
 
 local function preview_lines(agent)
 	local term = agent.term
-	if not term.bufnr or not vim.api.nvim_buf_is_valid(term.bufnr) then
+	if not term or not term.bufnr or not vim.api.nvim_buf_is_valid(term.bufnr) then
 		return {}
 	end
 	local lines = vim.api.nvim_buf_get_lines(term.bufnr, -60, -1, false)
@@ -293,6 +393,10 @@ function M._render_sidebar()
 		if a.title ~= "" then
 			table.insert(segs, { #lines, "KimiAgentsMuted", 0, -1 })
 			table.insert(lines, "  " .. a.title)
+		end
+		if not a.term then
+			table.insert(segs, { #lines, "KimiAgentsMuted", 0, -1 })
+			table.insert(lines, "  <CR> to resume session")
 		end
 		for _, p in ipairs(preview_lines(a)) do
 			table.insert(segs, { #lines, "KimiAgentsMuted", 0, -1 })
@@ -432,6 +536,27 @@ end
 
 -- -------------------------------------------------------------- lifecycle --
 
+---Create the toggleterm terminal for an agent — at spawn time, or lazily on
+---first toggle for agents restored from the registry.
+local function make_terminal(agent)
+	local Terminal = require("toggleterm.terminal").Terminal
+	agent.spawned_at = os.time()
+	agent.term = Terminal:new({
+		cmd = agent.cmd or "kimi",
+		direction = "float",
+		count = next_count(),
+		display_name = agent.name,
+		dir = agent.root or project_root(),
+		env = { KIMI_AGENT_NAME = agent.name },
+		on_exit = function()
+			agent.state = "exited"
+			refresh()
+			M.save_registry()
+		end,
+	})
+	return agent.term
+end
+
 ---@param name string|nil prompt when nil
 ---@param cmd string|nil defaults to "kimi"
 function M.spawn(name, cmd)
@@ -453,29 +578,24 @@ function M.spawn(name, cmd)
 		M.toggle(name)
 		return existing
 	end
-	local Terminal = require("toggleterm.terminal").Terminal
 	local root = project_root()
-	local agent = { name = name, state = "idle", title = "", session_id = nil, spawned_at = os.time(), root = root }
+	local agent =
+		{ name = name, cmd = cmd, state = "idle", title = "", session_id = nil, spawned_at = nil, root = root }
 	-- drop any stale status file from a previous life under the same name,
 	-- otherwise the poll would immediately mark the fresh agent with the
 	-- old state (e.g. "exited")
 	vim.fn.delete(STATUS_DIR .. "/" .. name .. ".json")
-	agent.term = Terminal:new({
-		cmd = cmd or "kimi",
-		direction = "float",
-		count = next_count(),
-		display_name = name,
-		dir = root,
-		env = { KIMI_AGENT_NAME = name },
-		on_exit = function()
-			agent.state = "exited"
-			refresh()
-		end,
-	})
+	make_terminal(agent)
 	table.insert(M.agents, agent)
 	M._last = name
 	start_timer()
 	agent.term:toggle()
+	-- fresh sessions get named inside kimi itself (/title) once the session
+	-- exists — see poll(); resumed sessions already have their title
+	if not cmd then
+		agent._want_title = true
+	end
+	M.save_registry()
 	refresh()
 	return agent
 end
@@ -485,6 +605,10 @@ function M.toggle(name)
 	if not agent then
 		notify("no agent named " .. name, vim.log.levels.WARN)
 		return
+	end
+	if not agent.term then
+		-- restored agent: first toggle resumes its kimi session
+		make_terminal(agent)
 	end
 	agent.term:toggle()
 	M._last = name
@@ -511,7 +635,9 @@ function M.kill(name, force)
 	if not force and vim.fn.confirm("Kill agent '" .. name .. "'?", "&Yes\n&No", 2) ~= 1 then
 		return
 	end
-	agent.term:shutdown()
+	if agent.term then
+		agent.term:shutdown()
+	end
 	-- tombstone the session so its late hook writes (SessionEnd fires on
 	-- shutdown) can't leak into a future same-named agent
 	if agent.session_id then
@@ -522,6 +648,7 @@ function M.kill(name, force)
 		M._last = nil
 	end
 	vim.fn.delete(STATUS_DIR .. "/" .. name .. ".json")
+	M.save_registry()
 	refresh()
 end
 
@@ -605,6 +732,7 @@ function M.resume()
 			-- stale status file keyed by session id; the poll matches on
 			-- session id too, so drop it to keep the resumed agent visible
 			vim.fn.delete(STATUS_DIR .. "/" .. choice.id .. ".json")
+			M.save_registry()
 			refresh()
 		end
 	end)
@@ -632,6 +760,8 @@ end
 -- ------------------------------------------------------------------- setup --
 
 function M.setup()
+	M.restore_registry()
+	vim.api.nvim_create_autocmd("VimLeavePre", { callback = M.save_registry })
 	local map = vim.keymap.set
 	map("n", "<leader>k", M.toggle_last, { desc = "kimi: toggle last agent" })
 	map("n", "<leader>kn", function()

--- a/lua/lq/configs/agents.lua
+++ b/lua/lq/configs/agents.lua
@@ -315,6 +315,9 @@ function M.restore_registry()
 	if restored > 0 then
 		M._last = M.agents[#M.agents].name
 		start_timer()
+		M.sidebar_toggle()
+		-- keep focus on the file, the sidebar is just there for visibility
+		vim.cmd("wincmd p")
 		refresh()
 		notify(restored .. " agent(s) restored — <CR> in the sidebar to resume")
 	end

--- a/lua/lq/configs/agents.lua
+++ b/lua/lq/configs/agents.lua
@@ -147,6 +147,7 @@ local function poll()
 		return
 	end
 	local changed = false
+	local need_save = false
 	for _, entry in ipairs(vim.fn.glob(STATUS_DIR .. "/*.json", false, true)) do
 		local ok, lines = pcall(vim.fn.readfile, entry)
 		if ok and lines[1] then
@@ -189,18 +190,20 @@ local function poll()
 					if new_state == "exited" and (not agent.term or agent._suppress_exit) then
 						new_state = nil
 					end
+					if new_state and new_state ~= "exited" then
+						-- first live status: genuine "exited" writes are
+						-- meaningful again from here on
+						agent._suppress_exit = nil
+					end
 					if new_state and agent.state ~= new_state then
 						agent.state = new_state
-						if new_state ~= "exited" then
-							agent._suppress_exit = nil
-						end
 						changed = true
 					end
 					if status.session_id and status.session_id ~= "" and not agent.session_id then
 						agent.session_id = status.session_id
 						-- persist right away; without this a crash before
 						-- VimLeavePre would lose the agent
-						M.save_registry()
+						need_save = true
 						changed = true
 					end
 					if status.title and status.title ~= "" then
@@ -230,9 +233,11 @@ local function poll()
 						local function send(chunk)
 							-- the agent may have been killed since; send only if
 							-- the same agent is registered and the job is alive
-							if find(agent.name) == agent and vim.fn.jobwait({ job }, 0)[1] == -1 then
-								pcall(vim.api.nvim_chan_send, job, chunk)
-							end
+							pcall(function()
+								if find(agent.name) == agent and vim.fn.jobwait({ job }, 0)[1] == -1 then
+									vim.api.nvim_chan_send(job, chunk)
+								end
+							end)
 						end
 						send("/title " .. agent.name)
 						vim.defer_fn(function()
@@ -243,6 +248,9 @@ local function poll()
 			end
 		end
 		::continue::
+	end
+	if need_save then
+		M.save_registry()
 	end
 	if changed then
 		refresh()
@@ -325,13 +333,21 @@ local function write_registry(root)
 		return
 	end
 	vim.fn.mkdir(REGISTRY_DIR, "p")
-	local tmp = path .. ".tmp"
+	-- pid-unique tmp: concurrent nvim instances must not clobber each
+	-- other's temp file (the read-merge-write window itself is an accepted
+	-- limitation — worst case is a missing sidebar entry, recoverable via kr)
+	local tmp = string.format("%s.%d.tmp", path, vim.uv.os_getpid())
 	local wf = io.open(tmp, "w")
 	if not wf then
 		notify("failed to write agent registry " .. path, vim.log.levels.WARN)
 		return
 	end
-	wf:write(vim.json.encode({ agents = out }))
+	if not wf:write(vim.json.encode({ agents = out })) then
+		wf:close()
+		vim.fn.delete(tmp)
+		notify("failed to write agent registry " .. path, vim.log.levels.WARN)
+		return
+	end
 	wf:close()
 	local ok, err = vim.uv.fs_rename(tmp, path)
 	if not ok then
@@ -373,9 +389,19 @@ function M.restore_registry()
 	end
 	local restored = 0
 	for _, e in ipairs(data.agents) do
-		if valid_entry(e) and not find(e.name) then
+		if valid_entry(e) and not find_by_session(e.session_id) then
+			-- two nvim instances may have persisted same-named agents with
+			-- different sessions; make the name unique instead of dropping one
+			local name = e.name
+			if find(name) then
+				local base, n = name, 2
+				repeat
+					name = base .. "-" .. n
+					n = n + 1
+				until not find(name)
+			end
 			table.insert(M.agents, {
-				name = e.name,
+				name = name,
 				term = nil,
 				cmd = "kimi --session " .. vim.fn.shellescape(e.session_id),
 				state = "idle",


### PR DESCRIPTION
## What

Two features for the kimi agent manager, plus README setup docs.

### 1. Agent persistence across Neovim restarts

Live agents (those with a known kimi session id) are saved per-project to `$KIMI_CODE_HOME/agent-registry/<sha256-of-root>.json` on spawn/kill/exit/`VimLeavePre`, and restored at setup when you reopen nvim in that project.

- Restored agents appear in the sidebar and statusline immediately, shown as `idle` with a `<CR> to resume session` hint line.
- Terminals are spawned **lazily** on first toggle (`kimi --session <id>`) — no kimi processes start until you actually open an agent.
- Agents that never received a prompt are not persisted: kimi creates sessions lazily on the first message, so there is no session to resume (verified against the live TUI: "No session yet — one will be created on your first message").
- Killing all agents removes the registry file.

### 2. Agent name becomes the kimi session title

Fresh agents now get their kimi session titled with the agent name (via `/title`), so the name shows up in kimi's own `/sessions`, in `<leader>kr`, and when resuming from a plain terminal — instead of the first prompt sentence.

Implementation detail: kimi creates sessions lazily on the first prompt and `/title` only works while the agent is idle, so the send is driven by the status poll once the session exists and the first turn ends. Restored agents are (re-)titled as well, covering sessions created before this feature.

Terminal quirk found experimentally: text and Enter must be `chansend`'ed as **separate chunks** — the kimi TUI drops a same-chunk `\r`.

### 3. README

New "Kimi agent manager" section: feature overview, requirements (`kimi` CLI + `jq`), the `[[hooks]]` block to add to `$KIMI_CODE_HOME/config.toml` (the one out-of-repo setup step), and the keymap reference.

## Verification

- Headless test suite passes, now running against an isolated `KIMI_CODE_HOME`, with a new persistence round-trip case (save → wipe → restore → lazy terminal on toggle → kill → registry cleanup).
- Live end-to-end test: spawned a real kimi agent headlessly, submitted a prompt, and verified `state.json` ends up with `title = <agent name>`. First attempt caught the lazy-session-creation issue and the same-chunk-Enter issue; both fixed and re-verified.

## Notes

- Testing left one session titled `e2e-titling` in this project's kimi history; harmless to delete or ignore.

## Review discussion (codex CLI, 3 rounds)

Verdict went from "not merge-ready" to **"merge-ready with documented limitations"**.

Round 1 (9 findings, all fixed): multi-instance registry clobbering (now merge-on-save keyed by session id), non-atomic registry write (tmp + rename), missing schema validation, session id not persisted until exit (now saved when first learned), current-root-only saves (now per covered root), premature end of exited-suppression after resume (`_suppress_exit` until first live status), `/title` send to a potentially dead job (identity + liveness checks, pcall), state gating, silent IO failures.

Round 2 (5 insufficient + 3 new, all fixed): `_suppress_exit` never clearing on a same-state live status, un-debounced saves (now one per poll pass), shared tmp filename across instances (now pid-unique), unchecked `wf:write`, duplicate agent names across instances making a session unrestorable (restore now dedupes by session id and unique-suffixes names).

Accepted limitation (documented in code): the read-merge-write window between concurrent nvim instances saving the same project registry — no file locking; worst case is a missing sidebar entry, recoverable via `<leader>kr`.
