### PR TITLE
fix: preserve Tab completion in Kimi terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ Validate with `kimi doctor`. Without these hooks everything still works, but age
 | `<leader>` `k` `n`| new named agent                        | `n`  |
 | `<leader>` `k` `r`| resume an existing kimi session        | `n`  |
 | `<leader>` `k` `a`| toggle the agents sidebar              | `n`  |
-| `Ctrl` `k`        | switch to next Kimi session in this project | `t` |
-| `Ctrl` `i`        | switch to previous Kimi session in this project | `t` |
+| `Alt` `k`         | switch to next Kimi session in this project | `t` |
+| `Alt` `i`         | switch to previous Kimi session in this project | `t` |
 
 Sidebar buffer mappings: `<CR>` toggle agent float, `i`/`k` jump between agents, `n` new, `r` resume, `d`/`x` kill, `q` close.
 
-The Ctrl mappings are available only while focused in a Kimi terminal. They close the current ToggleTerm float and open the next/previous live session for the current project; restored sessions are resumed on first visit. When the sidebar is open, Kimi floats fill the editor area to its left instead of overlapping it.
+The session mappings are available only while focused in a Kimi terminal. They close the current ToggleTerm float and open the next/previous live session for the current project; restored sessions are resumed on first visit. Tab is left unmodified for Kimi command completion. When the sidebar is open, Kimi floats fill the editor area to its left instead of overlapping it.
 
 ## Screenshots🖼️
 ![demo1](https://user-images.githubusercontent.com/61612323/153551187-156189ea-9e52-407c-8888-743439f5bf4c.png)

--- a/lua/lq/configs/agents.lua
+++ b/lua/lq/configs/agents.lua
@@ -760,17 +760,18 @@ local function make_terminal(agent)
 	return agent.term
 end
 
----Install navigation only in Kimi-managed terminal buffers. Other terminal
----buffers retain their normal Ctrl-I/Ctrl-K behavior.
+---Install navigation only in Kimi-managed terminal buffers. Use Alt-I/Alt-K:
+---Ctrl-I is the same terminal input as Tab, which must remain available for
+---shell and Kimi command completion.
 local function install_terminal_navigation(agent)
 	if not agent.term or not agent.term.bufnr or not vim.api.nvim_buf_is_valid(agent.term.bufnr) then
 		return
 	end
 	local opts = { buffer = agent.term.bufnr, silent = true }
-	vim.keymap.set("t", "<C-k>", function()
+	vim.keymap.set("t", "<M-k>", function()
 		M.cycle(1)
 	end, vim.tbl_extend("force", opts, { desc = "kimi: next session" }))
-	vim.keymap.set("t", "<C-i>", function()
+	vim.keymap.set("t", "<M-i>", function()
 		M.cycle(-1)
 	end, vim.tbl_extend("force", opts, { desc = "kimi: previous session" }))
 end


### PR DESCRIPTION
## Summary
- replace terminal session navigation bindings Ctrl-K/Ctrl-I with Alt-K/Alt-I
- keep Tab unmodified for Kimi command and shell completion
- document the updated shortcuts

## Verification
- stylua --check lua/lq/configs/agents.lua
- nvim headless Lua parse check
- git diff --check